### PR TITLE
Support For Inefficient Filtering of Results

### DIFF
--- a/djangocassandra/db/backends/cassandra/utils.py
+++ b/djangocassandra/db/backends/cassandra/utils.py
@@ -1,5 +1,13 @@
 from functools import cmp_to_key
 
+from django.db.utils import DatabaseError
+
+from django.db.models.sql.where import (
+    WhereNode,
+    AND,
+    OR
+)
+
 
 def _compare_rows(
     row1,
@@ -40,3 +48,67 @@ def sort_rows(
             ordering
         ))
     )
+
+
+def _test_row(
+    row,
+    column,
+    value,
+    lookup_type='exact'
+):
+    if 'exact' is lookup_type:
+        if row[column] != value:
+            return False
+
+    else:
+        raise DatabaseError(
+            'lookup_type %s not supported (yet).' % lookup_type
+        )
+
+    return True
+
+
+def _row_matches(
+    row,
+    where
+):
+    result = True
+    for child in where.children:
+        if isinstance(child, WhereNode):
+            matches = _row_matches(row, child)
+
+        else:
+            constraint, lookup_type, _, value = child
+            matches = _test_row(
+                row,
+                constraint.col,
+                value,
+                lookup_type
+            )
+
+        if AND == where.connector:
+            if not matches:
+                result = False
+                break
+
+        elif OR == where.connector:
+            result = result or matches
+
+    if where.negated:
+        return not result
+
+    else:
+        return result
+
+
+def filter_rows(
+    rows,
+    where
+):
+    return [
+        row for row in rows
+        if _row_matches(
+            row,
+            where
+        )
+    ]


### PR DESCRIPTION
Some utilities for providing support for inefficient filtering. There are some parts of django and third party apps that require this to function properly. There should probably be a warning thrown in the case of using an filter that is required to be processed in memory and only should ever be used on lightweight datasets.
