### PR TITLE
Insertion Tests and Perfomance Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 Cassandra support for the Django web framework
 ==============================================
 
+Install Apache Cassandra
+-------
+```
+follow directions on this link: http://wiki.apache.org/cassandra/DebianPackaging
+```
+
 Testing
 -------
 ```

--- a/djangocassandra/db/backends/cassandra/compiler.py
+++ b/djangocassandra/db/backends/cassandra/compiler.py
@@ -1,3 +1,5 @@
+import warnings
+
 from uuid import uuid4
 
 from django.db.utils import DatabaseError
@@ -24,6 +26,10 @@ from .utils import (
     sort_rows,
     filter_rows
 )
+
+class InefficientQueryWarning(RuntimeWarning):
+    pass
+
 
 
 class CassandraQuery(NonrelQuery):
@@ -307,22 +313,8 @@ class CassandraQuery(NonrelQuery):
         if isinstance(ordering, bool):
             return
 
-        if len(ordering) > 1:
-            if self.allows_inefficient:
-                self.can_order_efficiently = False
-                # TODO: Need to raise a warning whenever
-                #       we are allowing an inefficient
-                #       query.
-
-            else:
-                raise DatabaseError(
-                    'ORDER BY clauses can select a single column '
-                    'only. That column has to be the second column '
-                    'in a compound PRIMARY KEY.'
-                )
 
         self.ordering = []
-        order = ordering[0]
 
         for order in ordering:
             if isinstance(order, basestring):
@@ -355,8 +347,10 @@ class CassandraQuery(NonrelQuery):
                 ):
                     if self.allows_inefficient:
                         self.can_order_efficiently = False
-                        # TODO: Warning about efficiency
-
+                        warnings.warn(
+                            "Use of inefficient queries may cause performance issues.",
+                            InefficientQueryWarning
+                        )
                     else:
                         raise DatabaseError(
                             'ORDER BY clauses can select a single column '

--- a/djangocassandra/db/backends/cassandra/creation.py
+++ b/djangocassandra/db/backends/cassandra/creation.py
@@ -149,6 +149,12 @@ class DatabaseCreation(NonrelDatabaseCreation):
         self,
         field
     ):
+        '''
+        TODO:
+        Investigate wether this code is redundant.
+        After looking at Field.db_type() it seems like
+        the code here is duplicated.
+        '''
         data_type = self.data_types.get(field.get_internal_type())
 
         if None is data_type:
@@ -160,7 +166,7 @@ class DatabaseCreation(NonrelDatabaseCreation):
     def sql_create_model(
         self,
         model,
-        style,
+        style,  # Used for styling output
         known_models=set()
     ):
         connection_settings = self.connection.settings_dict

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,1 +1,14 @@
-SECRET_KEY="foo"
+SECRET_KEY = "foo"
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'djangocassandra.db.backends.cassandra',
+        'DEFAULT_KEYSPACE': 'test',
+        'CONTACT_POINTS': ('localhost',),
+        'PORT': 9042,
+        'KEYSPACES': {
+            'test': {
+            }
+        }
+    }
+}

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,0 +1,144 @@
+"""
+    This file tests the sorting performance of the djangocassandra back end.
+
+    Tests are implemented for the following features:
+        - Verifying that no sort is applied to already sorted data, when
+          properly queried.
+        - Verifying that this data is properly sorted.
+        - Verifying that only minimal sorting is applied to partially
+           sorted data, when properly queried.
+        - Verifying that this data is properly sorted.
+        - Verify that the djangocassandra backend raises proper warnings
+          for unaccelerated sorts.
+        - Verifying that the djangocassandra correctly sorts data in the
+          unaccelerated case.
+"""
+
+from django.conf import settings
+
+from django.db.models import (
+    Model,
+    CharField
+)
+
+from djangocassandra.db.backends.cassandra.base import (
+    CassandraQuery,
+    SQLCompiler
+)
+
+from djangocassandra.db.backends.cassandra.utils import (
+    sort_rows
+)
+
+from unittest import TestCase
+
+from util import (
+    connect_db,
+    create_db,
+    populate_db,
+    destroy_db
+)
+
+fake_data = [('a', 'b', 'c'), ('d', 'e', 'f'), ('g', 'h', 'i')]
+class SortingTestModel(Model):
+    field_1 = CharField(max_length=50)
+    field_2 = CharField(max_length=50)
+    field_3 = CharField(max_length=50)
+    
+STM = SortingTestModel
+    
+class TestOrderingCase(TestCase)
+    query = CassandraQuery(SQLCompiler, 
+                    [STM.field_1, STM.field_2, STM.field_3])
+                    
+    def setUp(self):
+        try:
+            try:
+                self.connection = connect_db()
+            except Exception, e:
+                self.connection = None
+                raise e
+            create_db(self.connection, SortingTestModel)
+            test_data = []
+            for x, y, z in fake_data:
+                test_data.append(SortingTestModel(x, y, z))
+            populate_db(self.connection, test_data)
+        except Exception, e:
+            self.tearDown()
+            raise e
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+class TestFullMatchOrdering(TestOrderingCase):
+    """
+        This case tests the situation in which the ordering request
+        matches with the data storage ordering, is exactly one fields,
+        and no sorting is needed.
+    """
+    
+    def test_correct_sort_application(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                self.query.orderby(['field_1'])
+                if self.query.can_order_efficiently:
+                    assert True
+                else:
+                    assert False
+            except InefficientQueryWarning:
+                assert False
+        raise
+
+    def test_correct_sort_results(self):
+        self.query.orderby(['field_1'])
+        results = self.query._get_query_results()
+        
+        print results
+
+        # Test data already sorted by field_1.
+        ### COMPARE HERE.
+
+
+class TestPartialMatchOrdering(TestOrderingCase):
+    """
+        This case tests the situation in which the first of the ordering
+        fields matches with the ordering of the stored data.
+        
+        Currently, this case is not implemented in the sorting, as
+        multiple search terms automatically make it inefficient and
+        trigger a full sort.
+    """
+    
+    def test_correct_sort_application(self):
+        pass
+
+    def test_correct_sort_results(self):
+        pass
+
+
+class TestDefaultOrdering(TestOrderingCase):
+    """
+        This case tests that the unaccelerated ordering works and raises
+        the correct warning about slow execution.
+    """
+
+    def test_for_warnings(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                self.query.orderby(['field_2'])
+                assert False
+            except InefficientQueryWarning:
+                assert True
+        raise
+
+    def test_correct_sort_results(self):
+        self.query.orderby(['field_2', 'field_3', 'field_1'])
+        ordering = self.query.ordering
+        results = self.query._get_query_results()
+        
+        print results
+        ### SORT DATA HERE. 2, 3, 1 ordering.
+        
+        ### COMPARE HERE.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,35 @@
 from unittest import TestCase
 
+from django.db.models import (
+    Model,
+    CharField
+)
+
+from util import (
+    connect_db,
+    create_db,
+    populate_db,
+    destroy_db
+)
 
 class TestImport(TestCase):
     def test_1(self):
         from djangocassandra.db.backends.cassandra.base import DatabaseClient
+
+class TestInsertion(TestCase):
+    fake_data = [('a', 'b', 'c'), ('d', 'e', 'f'), ('g', 'h', 'i')]
+    class InsertionTestModel(Model):
+        field_1 = CharField(max_length=50)
+        field_2 = CharField(max_length=50)
+        field_3 = CharField(max_length=50)
+
+    def test_insertion(self):
+        self.connection = connect_db()
+        create_db(self.connection, self.InsertionTestModel)
+        test_data = []
+        for x, y, z in self.fake_data:
+            test_data.append(self.InsertionTestModel(x, y, z))
+        populate_db(self.connection, test_data)
 
 
 class TestFiltering(TestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.db.models import (
+    Model,
+    CharField
+)
+from djangocassandra.db.backends.cassandra.base import DatabaseWrapper
+from djangocassandra.db.backends.cassandra.compiler import SQLInsertCompiler
+
+
+def connect_db():
+    connection = DatabaseWrapper(settings.DATABASES['default'])
+    connection.get_session()
+    return connection
+
+
+def create_db(connection, model):
+    connection.creation.sql_create_model(
+        model,
+        None
+    )
+
+
+def populate_db(connection, values):
+    for value in values:
+        value.save()    
+
+
+def destroy_db(connection):
+    session = connection.get_session()
+    for keyspace in settings.DATABASES['default']['KEYSPACES']:
+        session.execute('drop keyspace %s;' % keyspace,)


### PR DESCRIPTION
This work is from @mgehlke. Rebased for cleanlyness. This work majorly consists of sorting tests and adding in some warnings for low perfomance cases.
- Added in initial warning on inefficient search and added in test stubs for search functions.
- Added utility methods for connecting, creating and destroying test databases.
- Hooked up connecting, creating and destroy methods in the sorting unit tests setUp and tearDown methods respectively.
- Added SetUp and TearDown Methods
- Added in SetUp and TearDown methods for unit tests related to sorting.
- Added Test for Insertion
- Added test to see if elements can be correctly inserted in to the database.
- Added Apache wiki about installation of Debian packages
- Implemented sorting tests. Incorrect usage of query cache results, needs to be changed.
- Correctly noted that case 2 (partial match) isn't currently accelerated.
- Added Introspection Statements
- Added statements to see the type of return values and if I'm on the right track.
