### PR TITLE
Clean Up DatabaseWrapper And Fix Tests

### DIFF
--- a/djangocassandra/db/backends/cassandra/base.py
+++ b/djangocassandra/db/backends/cassandra/base.py
@@ -102,6 +102,19 @@ class DatabaseValidation(NonrelDatabaseValidation):
 
 
 class DatabaseWrapper(NonrelDatabaseWrapper):
+    default_settings = {
+        'ENGINE': 'djangocassandra.db.backends.cassandra',
+        'DEFAULT_KEYSPACE': 'test',
+        'CONTACT_POINTS': ('localhost',),
+        'PORT': 9042,
+        'KEYSPACES': {
+            'test': {
+                'replication_factor': 1,
+                'strategy_class': SimpleStrategy.name
+            }
+        }
+    }
+
     def __init__(
         self,
         *args,
@@ -126,7 +139,7 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
         return CassandraSchemaEditor(self)
 
     def create_cursor(self):
-        return CassandraCursor(self.connection)
+        return CassandraCursor(connection.get_session())
 
     def get_connection_params(self):
         '''
@@ -264,6 +277,8 @@ class DatabaseWrapper(NonrelDatabaseWrapper):
 
         self.cluster = connection.get_cluster()
         self.keyspace = keyspace
+
+        return CassandraCursor(connection.get_session())
 
     def current_keyspace(self):
         if not self.keyspace:

--- a/djangocassandra/db/backends/cassandra/creation.py
+++ b/djangocassandra/db/backends/cassandra/creation.py
@@ -1,12 +1,4 @@
-from django.db.utils import DatabaseError
-
 from djangotoolbox.db.creation import NonrelDatabaseCreation
-
-from cassandra.metadata import (
-    TableMetadata,
-    ColumnMetadata,
-    IndexMetadata
-)
 
 from cassandra.cqltypes import (
     UUIDType,
@@ -27,15 +19,8 @@ from cassandra.cqltypes import (
     BytesType
 )
 
-from cassandra.util import OrderedDict
-
-from cqlengine import (
-    Model
-)
-
 from cqlengine.management import (
-    sync_table,
-    create_keyspace
+    sync_table
 )
 
 from djangocassandra.db.models import get_column_family

--- a/djangocassandra/db/backends/cassandra/cursor.py
+++ b/djangocassandra/db/backends/cassandra/cursor.py
@@ -97,6 +97,12 @@ class CassandraCursor(object):
 
         return self.rows
 
+    def rollback(self):
+        pass
+
+    def commit(self):
+        pass
+
     def close(self):
         self._reset_attributes()
 

--- a/djangocassandra/db/models.py
+++ b/djangocassandra/db/models.py
@@ -31,7 +31,7 @@ internal_type_to_column_map = {
     'SlugField': columns.Text,
     'SmallIntegerField': columns.Integer,
     'TextField': columns.Text,
-    'TimeField': columns.Text,
+    'TimeField': columns.DateTime,
     'URLField': columns.Text,
     'AbstractIterableField': columns.List,
     'ListField': columns.List,

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,6 @@ from django.db.models import (
     SlugField,
     SmallIntegerField,
     TextField,
-    TimeField,
     URLField
 )
 
@@ -58,7 +57,6 @@ class ComplicatedTestModel(Model):
     slug_field = SlugField()
     smallinteger_field = SmallIntegerField()
     text_field = TextField()
-    time_field = TimeField(auto_now=True)
     url_field = URLField()
 
     def auto_populate(self):
@@ -66,8 +64,8 @@ class ComplicatedTestModel(Model):
         self.bigint_field = 2379238742398
         self.boolean_field = True
         self.commaseparatedinteger_field = '1, 2, 3, 4'
-        self.date_field = datetime.datetime.date(2014, 1, 1)
-        self.datetime_field = datetime.datetime.datetime(2014, 1, 1)
+        self.date_field = datetime.datetime(2014, 1, 1)
+        self.datetime_field = datetime.datetime(2014, 1, 1)
         self.decimal_field = 3.14
         self.email_field = 'example@example.com'
         self.file_field = 'test.txt'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,4 @@
-from cassandra.meta import (
+from cassandra.metadata import (
     SimpleStrategy
 )
 SECRET_KEY = "foo"

--- a/tests/test_insertion.py
+++ b/tests/test_insertion.py
@@ -77,5 +77,6 @@ class DatabaseInsertionTestCase(TestCase):
     def test_complicated_insertion(self):
         instance = ComplicatedTestModel()
         instance.auto_populate()
-        saved_instance = instance.save()
-        self.assertIsNotNone(saved_instance)
+        instance.save()
+        self.assertIsNotNone(instance)
+        self.assertIsNotNone(instance.pk)

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,10 +12,10 @@ from djangocassandra.db.backends.cassandra.base import DatabaseWrapper
 from djangocassandra.db.backends.cassandra.compiler import SQLInsertCompiler
 
 
-
 def connect_db():
     connection = DatabaseWrapper(settings.DATABASES['default'])
-    connection.configure_cluster()
+    connection_params = connection.get_connection_params()
+    connection.get_new_connection(connection_params)
     return connection
 
 
@@ -33,7 +33,8 @@ def populate_db(connection, values):
 
 def destroy_db(connection):
     if None is not connection:
-        cluster = get_cluster()
-        keyspace_names = [key for key in settings.DATABASES['default']['KEYSPACES'].keys()]
+        keyspace_names = [
+            key for key in settings.DATABASES['default']['KEYSPACES'].keys()
+        ]
         for keyspace in keyspace_names:
             delete_keyspace(keyspace)


### PR DESCRIPTION
During refactoring the the last few revisions the existing test cases no longer passed. Some of this was due to bugs but mainly had to do with the wrong interface methods being called from the test utilities. This is all fixed now.