### PR TITLE
Fixing SchemaEditor and AutoFieldUUID

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -1,0 +1,34 @@
+import uuid
+
+from django.db.models import AutoField
+
+
+class AutoFieldUUID(AutoField):
+    def to_python(
+        self,
+        value
+    ):
+        if (
+            value is None or
+            isinstance(value, uuid.UUID)
+        ):
+            return value
+
+        try:
+            return uuid.UUID(value)
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+                params={'value': value},
+            )
+
+    def get_prep_value(self, value):
+        value = super(AutoField, self).get_prep_value(value)
+        if (
+            value is None or
+            isinstance(value, uuid.UUID)
+        ):
+            return value
+
+        return uuid.UUID(value)


### PR DESCRIPTION
* I think the SchemaEditor is functional now at least for simple migrations across one db and without changing keyspaces.
* Added an AutoFieldUUID to djangocassandra.db.fields that handles UUID primary keys correctly. This should be used instead of Django's default AutoField class