### PR TITLE
In Memory Operations (Relational Support)

### DIFF
--- a/djangocassandra/db/backends/cassandra/exceptions.py
+++ b/djangocassandra/db/backends/cassandra/exceptions.py
@@ -1,0 +1,24 @@
+from django.db import (
+    NotSupportedError
+)
+
+class InefficientQueryError(NotSupportedError):
+    message = (
+        'Innefficent queries are not allowed on this model. '
+        'Make sure if you are filtering that you are only '
+        'filtering on either primary key or indexed fields '
+        'and that if you are ordering that you are only '
+        'ordering on fields that are components of compound '
+        'primary keys.\n\nAlternatively you can enable '
+        'inefficient filtering and ordering in your database '
+        'by setting the ALLOW_INEFFICIENT_QUERIES=True in '
+        'your settings.py or you can set this per model in '
+        'the CassandraMeta class for you model '
+        '"allow_inefficient_queries=True".'
+    )
+
+    def __init__(self, query):
+        self.query = query
+
+    def __str__(self):
+        return  (self.message + ':\n%s') % (repr(self.query),)

--- a/djangocassandra/db/backends/cassandra/predicate.py
+++ b/djangocassandra/db/backends/cassandra/predicate.py
@@ -1,0 +1,363 @@
+#   Copyright 2010 BSN, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import re
+from .utils import combine_rows
+
+SECONDARY_INDEX_SUPPORT_ENABLED = True
+
+class InvalidSortSpecException(Exception):
+    def __init__(self):
+        super(InvalidSortSpecException, self).__init__(
+            'The row sort spec must be a sort spec '
+            'tuple/list or a tuple/list of sort specs'
+        )
+
+class InvalidRowCombinationOpException(Exception):
+    def __init__(self):
+        super(InvalidRowCombinationOpException, self).__init__(
+            'Invalid row combination operation'
+        )
+
+class InvalidPredicateOpException(Exception):
+    def __init__(self):
+        super(InvalidPredicateOpException, self).__init__(
+            'Invalid/unsupported query predicate operation'
+        )
+
+
+COMPOUND_OP_AND = 1
+COMPOUND_OP_OR = 2
+
+class RangePredicate(object):
+    def __init__(
+        self,
+        column,
+        start=None,
+        start_inclusive=True,
+        end=None,
+        end_inclusive=True
+    ):
+        self.column = column
+        self.start = start
+        self.start_inclusive = start_inclusive
+        self.end = end
+        self.end_inclusive = end_inclusive
+    
+    def __repr__(self):
+        s = '(RANGE: '
+        if self.start:
+            op = '<=' if self.start_inclusive else '<'
+            s += (unicode(self.start) + op)
+        s += self.column
+        if self.end:
+            op = '>=' if self.end_inclusive else '>'
+            s += (op + unicode(self.end))
+        s += ')'
+        return s
+
+    def _is_exact(self):
+        return (
+            (self.start != None) and
+            (self.start == self.end) and
+            self.start_inclusive and
+            self.end_inclusive
+        )
+    
+    def can_evaluate_efficiently(self, pk_column, indexed_columns):
+        return (
+            self.column == pk_column or (
+                self.column in indexed_columns and self._is_exact()
+            )
+        )
+    
+    def incorporate_range_op(self, column, op, value, parent_compound_op):
+        if column != self.column:
+            return False
+        
+        # FIXME: The following logic could probably be tightened up a bit
+        # (although perhaps at the expense of clarity?)
+        if parent_compound_op == COMPOUND_OP_AND:
+            if op == 'gt':
+                if self.start == None or value >= self.start:
+                    self.start = value
+                    self.start_inclusive = False
+                    return True
+            elif op == 'gte':
+                if self.start == None or value > self.start:
+                    self.start = value
+                    self.start_inclusive = True
+                    return True
+            elif op == 'lt':
+                if self.end == None or value <= self.end:
+                    self.end = value
+                    self.end_inclusive = False
+                    return True
+            elif op == 'lte':
+                if self.end == None or value < self.end:
+                    self.end = value
+                    self.end_inclusive = True
+                    return True
+            elif op == 'exact':
+                if self._matches_value(value):
+                    self.start = self.end = value
+                    self.start_inclusive = self.end_inclusive = True
+                    return True
+            elif op == 'startswith':
+                # For the end value we increment the ordinal value of the last character
+                # in the start value and make the end value not inclusive
+                end_value = value[:-1] + chr(ord(value[-1])+1)
+                if (((self.start == None) or (value > self.start)) and
+                    ((self.end == None) or (end_value <= self.end))):
+                    self.start = value
+                    self.end = end_value
+                    self.start_inclusive = True
+                    self.end_inclusive = False
+                    return True
+            else:
+                raise InvalidPredicateOpException()
+        elif parent_compound_op == COMPOUND_OP_OR:
+            if op == 'gt':
+                if self.start == None or value < self.start:
+                    self.start = value
+                    self.start_inclusive = False
+                    return True
+            elif op == 'gte':
+                if self.start == None or value <= self.start:
+                    self.start = value
+                    self.start_inclusive = True
+                    return True
+            elif op == 'lt':
+                if self.end == None or value > self.end:
+                    self.end = value
+                    self.end_inclusive = False
+                    return True
+            elif op == 'lte':
+                if self.end == None or value >= self.end:
+                    self.end = value
+                    self.end_inclusive = True
+                    return True
+            elif op == 'exact':
+                if self._matches_value(value):
+                    return True
+            elif op == 'startswith':
+                # For the end value we increment the ordinal value of the last character
+                # in the start value and make the end value not inclusive
+                end_value = value[:-1] + chr(ord(value[-1])+1)
+                if (((self.start == None) or (value <= self.start)) and
+                    ((self.end == None) or (end_value > self.end))):
+                    self.start = value
+                    self.end = end_value
+                    self.start_inclusive = True
+                    self.end_inclusive = False
+                    return True
+        else:
+            raise InvalidPredicateOpException()
+    
+        return False
+    
+    def _matches_value(self, value):
+        if value == None:
+            return False
+        if self.start != None:
+            if self.start_inclusive:
+                if value < self.start:
+                    return False
+            elif value <= self.start:
+                return False
+        if self.end != None:
+            if self.end_inclusive:
+                if value > self.end:
+                    return False
+            elif value >= self.end:
+                return False
+        return True
+    
+    def row_matches(self, row):
+        value = row.get(self.column, None)
+        return self._matches_value(value)
+    
+    def get_matching_rows(self, query):
+        rows = query.get_row_range(self)
+        return rows
+    
+class OperationPredicate(object):
+    def __init__(self, column, op, value=None):
+        self.column = column
+        self.op = op
+        self.value = value
+        if op == 'regex' or op == 'iregex':
+            flags = re.I if op == 'iregex' else 0
+            self.pattern = re.compile(value, flags)
+    
+    def __repr__(self):
+        return '(OP: ' + self.op + ':' + unicode(self.value) + ')'
+    
+    def can_evaluate_efficiently(self, pk_column, indexed_columns):
+        return False
+
+    def row_matches(self, row):
+        row_value = row.get(self.column, None)
+        if self.op == 'isnull':
+            return row_value == None
+        # FIXME: Not sure if the following test is correct in all cases
+        if (row_value == None) or (self.value == None):
+            return False
+        if self.op == 'in':
+            return row_value in self.value
+        if self.op == 'istartswith':
+            return row_value.lower().startswith(self.value.lower())
+        elif self.op == 'endswith':
+            return row_value.endswith(self.value)
+        elif self.op == 'iendswith':
+            return row_value.lower().endswith(self.value.lower())
+        elif self.op == 'iexact':
+            return row_value.lower() == self.value.lower()
+        elif self.op == 'contains':
+            return row_value.find(self.value) >= 0
+        elif self.op == 'icontains':
+            return row_value.lower().find(self.value.lower()) >= 0
+        elif self.op == 'regex' or self.op == 'iregex':
+            return self.pattern.match(row_value) != None
+        else:
+            raise InvalidPredicateOpException()
+    
+    def incorporate_range_op(self, column, op, value, parent_compound_op):
+        return False
+    
+    def get_matching_rows(self, query):
+        # get_matching_rows should only be called for predicates that can
+        # be evaluated efficiently, which is not the case for OperationPredicate's
+        raise NotImplementedError('get_matching_rows() called for inefficient predicate')
+    
+class CompoundPredicate(object):
+    def __init__(self, op, negated=False, children=None):
+        self.op = op
+        self.negated = negated
+        self.children = children
+        if self.children == None:
+            self.children = []
+    
+    def __repr__(self):
+        s = '('
+        if self.negated:
+            s += 'NOT '
+        s += ('AND' if self.op == COMPOUND_OP_AND else 'OR')
+        s += ': '
+        first_time = True
+        if self.children:
+            for child_predicate in self.children:
+                if first_time:
+                    first_time = False
+                else:
+                    s += ','
+                s += unicode(child_predicate)
+        s += ')'
+        return s
+    
+    def can_evaluate_efficiently(self, pk_column, indexed_columns):
+        if self.negated:
+            return False
+        if self.op == COMPOUND_OP_AND:
+            for child in self.children:
+                if child.can_evaluate_efficiently(pk_column, indexed_columns):
+                    return True
+            else:
+                return False
+        elif self.op == COMPOUND_OP_OR:
+            for child in self.children:
+                if not child.can_evaluate_efficiently(pk_column, indexed_columns):
+                    return False
+            else:
+                return True
+        else:
+            raise InvalidPredicateOpException()
+
+    def row_matches_subset(self, row, subset):
+        if self.op == COMPOUND_OP_AND:
+            for predicate in subset:
+                if not predicate.row_matches(row):
+                    matches = False
+                    break
+            else:
+                matches = True
+        elif self.op == COMPOUND_OP_OR:
+            for predicate in subset:
+                if predicate.row_matches(row):
+                    matches =  True
+                    break
+            else:
+                matches = False
+        else:
+            raise InvalidPredicateOpException()
+        
+        if self.negated:
+            matches = not matches
+            
+        return matches
+        
+    def row_matches(self, row):
+        return self.row_matches_subset(row, self.children)
+    
+    def incorporate_range_op(self, column, op, value, parent_predicate):
+        return False
+    
+    def add_filter(self, column, op, value):
+        if op in ('lt', 'lte', 'gt', 'gte', 'exact', 'startswith'):
+            for child in self.children:
+                if child.incorporate_range_op(column, op, value, self.op):
+                    return
+            else:
+                child = RangePredicate(column)
+                incorporated = child.incorporate_range_op(column, op, value, COMPOUND_OP_AND)
+                assert incorporated
+                self.children.append(child)
+        else:
+            child = OperationPredicate(column, op, value)
+            self.children.append(child)
+    
+    def add_child(self, child_query_node):
+        self.children.append(child_query_node)
+    
+    def get_matching_rows(self, query):
+        pk_column = query.query.get_meta().pk.column
+        
+        # In the first pass we handle the query nodes that can be processed
+        # efficiently. Hopefully, in most cases, this will result in a
+        # subset of the rows that is much smaller than the overall number
+        # of rows so we only have to run the inefficient query predicates
+        # over this smaller number of rows.
+        if self.can_evaluate_efficiently(pk_column, query.indexed_columns):
+            inefficient_predicates = []
+            result = None
+            for predicate in self.children:
+                if predicate.can_evaluate_efficiently(pk_column, query.indexed_columns):
+                    rows = predicate.get_matching_rows(query)
+                    result = combine_rows(result, rows, self.op, pk_column)
+
+                else:
+                    inefficient_predicates.append(predicate)
+        else:
+            inefficient_predicates = self.children
+            result = query.get_all_rows()
+        
+        if None is result:
+            result = []
+            
+        # Now 
+        if len(inefficient_predicates) > 0:
+            result = [row for row in result if self.row_matches_subset(row, inefficient_predicates)]
+            
+        return result
+

--- a/djangocassandra/db/backends/cassandra/utils.py
+++ b/djangocassandra/db/backends/cassandra/utils.py
@@ -1,4 +1,9 @@
-from functools import cmp_to_key
+import sys
+
+from functools import (
+    cmp_to_key,
+    wraps
+)
 
 from django.db.utils import DatabaseError
 
@@ -7,6 +12,16 @@ from django.db.models.sql.where import (
     AND,
     OR
 )
+
+
+def safe_call(func):
+    @wraps(func)
+    def _func(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception, e:
+            raise DatabaseError, DatabaseError(*tuple(e)), sys.exc_info()[2]
+    return _func
 
 
 def _compare_rows(
@@ -29,25 +44,6 @@ def _compare_rows(
             result = 0
 
     return result
-
-
-def sort_rows(
-    rows,
-    ordering
-):
-    if None is ordering:
-        return rows
-
-    if (type(ordering) != list) and (type(ordering) != tuple):
-        ordering = (ordering,)
-
-    rows.sort(
-        key=cmp_to_key(lambda row1, row2: _compare_rows(
-            row1,
-            row2,
-            ordering
-        ))
-    )
 
 
 def _test_row(
@@ -112,3 +108,140 @@ def filter_rows(
             where
         )
     ]
+
+
+#   Copyright 2010 BSN, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+def _cmp_to_key(comparison_function):
+    """
+    Convert a cmp= function into a key= function.
+    This is built in to Python 2.7, but we define it ourselves
+    to work with older versions of Python
+    """
+    class K(object):
+        def __init__(self, obj, *args):
+            self.obj = obj
+        def __lt__(self, other):
+            return comparison_function(self.obj, other.obj) < 0
+        def __gt__(self, other):
+            return comparison_function(self.obj, other.obj) > 0
+        def __eq__(self, other):
+            return comparison_function(self.obj, other.obj) == 0
+        def __le__(self, other):
+            return comparison_function(self.obj, other.obj) <= 0
+        def __ge__(self, other):
+            return comparison_function(self.obj, other.obj) >= 0
+        def __ne__(self, other):
+            return comparison_function(self.obj, other.obj) != 0
+    return K
+
+def _compare_rows(row1, row2, sort_spec_list):
+    for sort_spec in sort_spec_list:
+        column_name = sort_spec[0]
+        reverse = sort_spec[1] if len(sort_spec) > 1 else False
+        row1_value = row1.get(column_name, None)
+        row2_value = row2.get(column_name, None)
+        result = cmp(row1_value, row2_value)
+        if result != 0:
+            if reverse:
+                result = -result
+            break;
+    else:
+        result = 0
+    return result
+
+def sort_rows(rows, sort_spec):
+    if sort_spec == None:
+        return rows
+
+    if (type(sort_spec) != list) and (type(sort_spec) != tuple):
+        raise InvalidSortSpecException()
+    
+    # The sort spec can be either a single sort spec tuple or a list/tuple
+    # of sort spec tuple. To simplify the code below we convert the case
+    # where it's a single sort spec tuple to a 1-element tuple containing
+    # the sort spec tuple here.
+    if (type(sort_spec[0]) == list) or (type(sort_spec[0]) == tuple):
+        sort_spec_list = sort_spec
+    else:
+        sort_spec_list = (sort_spec,)
+    
+    rows.sort(key=_cmp_to_key(lambda row1, row2: _compare_rows(row1, row2, sort_spec_list)))
+
+COMBINE_INTERSECTION = 1
+COMBINE_UNION = 2
+
+def combine_rows(rows1, rows2, op, primary_key_column):
+    # Handle cases where rows1 and/or rows2 are None or empty
+    if not rows1:
+        return list(rows2) if rows2 and (op == COMBINE_UNION) else []
+    if not rows2:
+        return list(rows1) if (op == COMBINE_UNION) else []
+    
+    # We're going to iterate over the lists in parallel and
+    # compare the elements so we need both lists to be sorted
+    # Note that this means that the input arguments will be modified.
+    # We could optionally clone the rows first, but then we'd incur
+    # the overhead of the copy. For now, we'll just always sort
+    # in place, and if it turns out to be a problem we can add the
+    # option to copy
+    sort_rows(rows1,(primary_key_column,))
+    sort_rows(rows2,(primary_key_column,))
+    
+    combined_rows = []
+    iter1 = iter(rows1)
+    iter2 = iter(rows2)
+    update1 = update2 = True
+    
+    while True:
+        # Get the next element from one or both of the lists
+        if update1:
+            try:
+                row1 = iter1.next()
+            except:
+                row1 = None
+            value1 = row1.get(primary_key_column, None) if row1 != None else None
+        if update2:
+            try:
+                row2 = iter2.next()
+            except:
+                row2 = None
+            value2 = row2.get(primary_key_column, None) if row2 != None else None
+        
+        if (op == COMBINE_INTERSECTION):
+            # If we've reached the end of either list and we're doing an intersection,
+            # then we're done
+            if (row1 == None) or (row2 == None):
+                break
+        
+            if value1 == value2:
+                combined_rows.append(row1)
+        elif (op == COMBINE_UNION):
+            if row1 == None:
+                if row2 == None:
+                    break;
+                combined_rows.append(row2)
+            elif (row2 == None) or (value1 <= value2):
+                combined_rows.append(row1)
+            else:
+                combined_rows.append(row2)
+        else:
+            raise InvalidCombineRowsOpException()
+        
+        update1 = (row2 == None) or (value1 <= value2)
+        update2 = (row1 == None) or (value2 <= value1)
+    
+    return combined_rows

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,14 +1,24 @@
+import os
+import uuid
+
 from cassandra.metadata import (
     SimpleStrategy
 )
-SECRET_KEY = "foo"
+
+SECRET_KEY = uuid.uuid4().hex
 
 DATABASES = {
     'default': {
         'ENGINE': 'djangocassandra.db.backends.cassandra',
         'DEFAULT_KEYSPACE': 'test',
-        'CONTACT_POINTS': ('localhost',),
-        'PORT': 9042,
+        'CONTACT_POINTS': (os.environ.get(
+            'DJANGOCASSANDRA_TEST_HOST',
+            'localhost'
+        ),),
+        'PORT': int(os.environ.get(
+            'DJANGOCASSANDRA_TEST_PORT',
+            9042
+        )),
         'KEYSPACES': {
             'test': {
                 'replication_factor': 1,


### PR DESCRIPTION
* Ported predicate.py module from https://github.com/vaterlaus/django_cassandra_backend to handle in memory sorting and filtering operations.
* Modified compiler.py to take advantage of predicate.py in retriving and filtering results.
* Modified settings.py to look for environment variables to configure your cassandra host and port (original defaults are still in place i.e localhost:9042)