### PR TITLE
Foreign Keys

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -1,9 +1,16 @@
 import uuid
 
 from django.db.models import AutoField
+from django.utils.translation import ugettext_lazy as _
 
 
 class AutoFieldUUID(AutoField):
+    description = _('UUID')
+
+    default_error_messages = {
+        'invalid': _("'%(value)s' value must be a valid UUID."),
+    }
+
     def to_python(
         self,
         value
@@ -32,3 +39,9 @@ class AutoFieldUUID(AutoField):
             return value
 
         return uuid.UUID(value)
+
+    def get_internal_type(self):
+        return 'AutoFieldUUID'
+
+    def get_auto_value(self):
+        return uuid.uuid4()

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -3,4 +3,36 @@
 Usage
 =====
 
-Coming Soon
+Djangocassandra is designed to be used with the **stock** version of Django 1.7 (specifically tested with Django 1.7.7). Many features of the Django ORM are supported however there are a few exceptions that should be taken into consideration when using djangocassandra as your database backend.
+
+.. _autofields:
+
+AutoFields
+----------
+
+Currently Django only supports integer auto fields. This isn't a huge issue as Cassandra works just fine if you use integer primary keys however when using Cassandra you can use any column type as your primary keys. Here's a few solutions to this problem that you may find useful:
+
+Use The Included AutoFieldUUID Model Field
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+I have included in the djangocassandra project an AutoFieldUUID model field that correctly handles the generation of uuid4() UUID's upon creation. You must specifically define the autofield on all of your models as shown::
+
+  class AutoIdModel(Model):
+        id = AutoFieldUUID(primary_key=True)
+        data = CharField(
+            max_length=64
+        )
+
+
+Use The Knotis Fork Of Django
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Instead of installing stock Django you can install the `Knotis custom-autofield branch <https://github.com/Knotis/django/tree/custom-autofield>`_ (https://github.com/Knotis/django/tree/custom-autofield) of Django which provides you a variable in settings.py to provide your own AutoField like so::
+
+  CUSTOM_AUTOFIELD_CLASS='djangocassandra.db.fields.AutoFieldUUID'
+
+Doing this will make Django use the auto field class you defined whenever it would normally add the stock integer based auto field.
+
+Installing the Knotis fork of Django is as simple as running:
+
+``pip install git+https://github.com/Knotis/django@custom-autofield``

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,8 +22,11 @@ from django.db.models import (
     SlugField,
     SmallIntegerField,
     TextField,
-    URLField
+    URLField,
+    ForeignKey
 )
+
+from djangocassandra.db.fields import AutoFieldUUID
 
 
 class SimpleTestModel(Model):
@@ -83,12 +86,31 @@ class ComplicatedTestModel(Model):
         self.url_field = 'http://example.com'
 
 
-class RealatedTestModelA(Model):
-    pass
+class RelatedModelA(Model):
+    id = AutoFieldUUID(primary_key=True)
+    data = CharField(
+        max_length=64
+    )
 
 
-class RelatedTestModelB(Model):
-    pass
+class RelatedModelB(Model):
+    id = AutoFieldUUID(primary_key=True)
+    model_a = ForeignKey(
+        RelatedModelA,
+        null=True
+    )
+
+
+class RelatedModelC(Model):
+    id = AutoFieldUUID(primary_key=True)
+    model_a = ForeignKey(
+        RelatedModelA,
+        null=True
+    )
+    model_b = ForeignKey(
+        RelatedModelB,
+        null=True
+    )
 
 
 class ClusterPrimaryKeyModel(Model):

--- a/tests/test_insertion.py
+++ b/tests/test_insertion.py
@@ -48,8 +48,8 @@ class DatabaseInsertionTestCase(TestCase):
             field_3='raw'
         )
 
-        self.assertTrue(
-            isinstance(inserted.pk, UUID)
+        self.assertIsNotNone(
+            inserted.pk
         )
 
         self.assertEqual('foo', inserted.field_1)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -213,7 +213,7 @@ class DatabaseClusteringKeyTestCase(TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            
+
             filtered_rows_ordered = list(
                 manager.filter(
                     field_1='bbbb'

--- a/tests/test_related.py
+++ b/tests/test_related.py
@@ -1,0 +1,114 @@
+from unittest import TestCase
+
+from .models import (
+    RelatedModelA,
+    RelatedModelB,
+    RelatedModelC
+)
+
+from .util import (
+    connect_db,
+    destroy_db,
+    create_model
+)
+
+
+class RelatedModelCreationTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_create_related_models(self):
+        create_model(
+            self.connection,
+            RelatedModelA
+        )
+        create_model(
+            self.connection,
+            RelatedModelB
+        )
+        create_model(
+            self.connection,
+            RelatedModelC
+        )
+
+        objA = RelatedModelA.objects.create(data='FooBarLel')
+        objB = RelatedModelB.objects.create(model_a=objA)
+        objC = RelatedModelC.objects.create(
+            model_a=objA,
+            model_b=objB
+        )
+
+
+class RelatedModelQueryTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        self.cached_rows = {}
+
+        create_model(
+            self.connection,
+            RelatedModelA
+        )
+        create_model(
+            self.connection,
+            RelatedModelB
+        )
+        create_model(
+            self.connection,
+            RelatedModelC
+        )
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_related_query(self):
+        obj_a0 = RelatedModelA.objects.create(
+            data='MadFooBar'
+        )
+
+        obj_b0 = RelatedModelB.objects.create(
+            model_a=obj_a0
+        )
+
+        obj_c0 = RelatedModelC.objects.create(
+            model_a=obj_a0,
+            model_b=obj_b0
+        )
+
+        obj_a0_stored = RelatedModelA.objects.get(
+            pk=obj_a0.pk
+        )
+
+        obj_b0_stored = RelatedModelB.objects.get(
+            pk=obj_b0.pk
+        )
+
+        obj_c0_stored = RelatedModelC.objects.get(
+            pk=obj_c0.pk
+        )
+        
+        self.assertEqual(
+            obj_a0.data,
+            obj_a0_stored.data
+        )
+        self.assertEqual(
+            obj_b0.model_a.data,
+            obj_b0_stored.model_a.data
+        )
+        self.assertEqual(
+            obj_c0.model_a.data,
+            obj_c0_stored.model_a.data
+        )
+        self.assertEqual(
+            obj_c0.model_b.model_a.data,
+            obj_c0_stored.model_b.model_a.data
+        )


### PR DESCRIPTION
* Wrote tests to exercise Django ForeignKey creation and queries.
* Refactored AutoFieldUUID auto value creation into a method on the field class called "get_auto_value"
* In the case that the default Django AutoField is being used the database backend now counts the current rows in the column family and then sets the new insert. Auto-incrementing integer fields really only work on single node Cassandra clusters or clusters that replecate data across all nodes before responding not to mention counting the rows is expensive and not scalable. I pretty much just added this for compatibility, there could be a more efficient way to implement this.
* In all other cases the database backend looks for the "get_auto_value" method to be defined on the custom auto field.
* Updated "Usage" documentation.
* Fixed a bug where the backend couldn't properly determine that an order_by statement is efficent due to it not checking if the partition key has been filtered or not yet correctly.