### PR TITLE
Fix Creation Of Map, Set and List Fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.1.0',
+    version='0.1.1',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
Map, Set and List columns need extra parameters (key_type, value_type). I just make all key_types 'columns.Text' since I'm not sure the best way to handle other types of keys in Django. value_type is determined by the item_field attributes on those field classes.