### PR TITLE
Fix Inefficent Range Filtering Error

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -45,3 +45,16 @@ class AutoFieldUUID(AutoField):
 
     def get_auto_value(self):
         return uuid.uuid4()
+
+    def value_to_string(self, value):
+        if isinstance(value, basestring):
+            return value
+
+        try:
+            return value.hex
+        except (TypeError, ValueError):
+            raise exceptions.ValidationError(
+                self.error_messages['invalid'],
+                code='invalid',
+                params={'value': value},
+            )


### PR DESCRIPTION
There was an error in how the backend determines wether or not a range query can be evaluated efficiently by Cassandra. It was allowing attempts of efficent filtering on non-clustering columns.