### PR TITLE
Changing the spelling on index.rst

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -8,7 +8,7 @@
 
 .. _index:
 
-Djangocassandra - The Django Cassnadra Database Backend
+Djangocassandra - The Django Cassandra Database Backend
 =======================================================
 
 .. _overview:


### PR DESCRIPTION
Simple typo on the spelling of Cassandra 