### PR TITLE
AutoUUID Field Should Be Represented As String

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -1,10 +1,14 @@
 import uuid
 
-from django.db.models import AutoField
+from django.utils.six import with_metaclass
+from django.db.models import (
+    AutoField,
+    SubfieldBase
+)
 from django.utils.translation import ugettext_lazy as _
 
 
-class AutoFieldUUID(AutoField):
+class AutoFieldUUID(with_metaclass(SubfieldBase, AutoField)):
     description = _('UUID')
 
     default_error_messages = {
@@ -15,20 +19,11 @@ class AutoFieldUUID(AutoField):
         self,
         value
     ):
-        if (
-            value is None or
-            isinstance(value, uuid.UUID)
-        ):
-            return value
+        if isinstance(value, uuid.UUID):
+            return str(value)
 
-        try:
-            return uuid.UUID(value)
-        except (TypeError, ValueError):
-            raise exceptions.ValidationError(
-                self.error_messages['invalid'],
-                code='invalid',
-                params={'value': value},
-            )
+        else:
+            return value
 
     def get_prep_value(self, value):
         value = super(AutoField, self).get_prep_value(value)
@@ -51,7 +46,8 @@ class AutoFieldUUID(AutoField):
             return value
 
         try:
-            return value.hex
+            return str(value)
+
         except (TypeError, ValueError):
             raise exceptions.ValidationError(
                 self.error_messages['invalid'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.1.2',
+    version='0.1.4',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/test_related.py
+++ b/tests/test_related.py
@@ -39,7 +39,7 @@ class RelatedModelCreationTestCase(TestCase):
 
         objA = RelatedModelA.objects.create(data='FooBarLel')
         objB = RelatedModelB.objects.create(model_a=objA)
-        objC = RelatedModelC.objects.create(
+        RelatedModelC.objects.create(
             model_a=objA,
             model_b=objB
         )
@@ -95,7 +95,7 @@ class RelatedModelQueryTestCase(TestCase):
         obj_c0_stored = RelatedModelC.objects.get(
             pk=obj_c0.pk
         )
-        
+
         self.assertEqual(
             obj_a0.data,
             obj_a0_stored.data


### PR DESCRIPTION
Modified the AutoUUIDField class to_python method to convert the UUID field to a string representation when adding it to the class.