### PR TITLE
[Deliver #106712166] - Paging Functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
     - "pip install ."
     - "pip install nose"
-    - "pip install git+https://github.com/sethdenner/djangotoolbox.git@issue-55"
+    - "pip install djangotoolbox"
 
 env:
     - DJANGO_SETTINGS_MODULE=tests.settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 install:
     - "pip install ."
     - "pip install nose"
-    - "pip install djangotoolbox"
 
 env:
     - DJANGO_SETTINGS_MODULE=tests.settings

--- a/djangocassandra/db/models.py
+++ b/djangocassandra/db/models.py
@@ -2,10 +2,8 @@ from django.db.models import (
     Model
 )
 from django.db.models.manager import Manager
-from django.db.models.options import Options
 
 from cassandra.cqlengine import columns
-from cassandra.cqlengine.functions import Token
 from cassandra.cqlengine.models import (
     Model as CqlEngineModel,
     ModelMetaClass as CqlEngineModelMetaClass

--- a/djangocassandra/db/query.py
+++ b/djangocassandra/db/query.py
@@ -1,0 +1,19 @@
+from django.db.models.query import QuerySet as DjangoQuerySet
+
+
+class QuerySet(DjangoQuerySet):
+    def next(self, limit=None):
+        last_limit = len(self)
+        last = self[last_limit - 1]
+
+        new_set = self.model.objects.all()
+        new_set.where = self.query.where
+        new_set = new_set.filter(pk_token__gt=last.pk_token)
+
+        if None is not limit:
+            new_set = new_set[:limit]
+
+        else:
+            new_set = new_set[:last_limit]
+
+        return new_set

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     install_requires=[
         'django>=1.7, < 1.8',
         'cassandra-driver==2.5.1',
-        'blist'
+        'blist',
+        'djangotoolbox==1.7.0'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.1.8',
+    version='0.1.9',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '
@@ -40,7 +40,7 @@ setup(
     ],
     install_requires=[
         'django>=1.7, < 1.8',
-        'cassandra-driver',
+        'cassandra-driver==2.5.1',
         'blist'
     ],
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -27,6 +27,20 @@ from django.db.models import (
 )
 
 from djangocassandra.db.fields import AutoFieldUUID
+from djangocassandra.db.models import ColumnFamilyModel
+
+
+class ColumnFamilyTestModel(ColumnFamilyModel):
+    field_1 = CharField(
+        primary_key=True,
+        max_length=32
+    )
+    field_2 = CharField(
+        max_length=32
+    )
+    field_3 = CharField(
+        max_length=32
+    )
 
 
 class SimpleTestModel(Model):

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,10 +2,9 @@ from django.conf import settings
 
 from cassandra.cqlengine.management import delete_keyspace
 
-from djangocassandra.db.backends.cassandra.base import DatabaseWrapper
-
 
 def connect_db():
+    from djangocassandra.db.backends.cassandra.base import DatabaseWrapper
     connection = DatabaseWrapper(settings.DATABASES['default'])
     connection_params = connection.get_connection_params()
     connection.get_new_connection(connection_params)


### PR DESCRIPTION
Unfortunately this feature will not work out of the box. It will require your django models to inherit from djangocassandra.db.models.ColumnFamilyModel which has a custom manager/queryset which has the paging method attached to it (model.objects.next())

* Impelemented a ColumnFamilyModel class that your cassandra Models should inherit from.
* Impelemented a QuerySet method (djangocassandra.db.query.QuerySet) which has a pagination method called next()
* Implemented a ColumnFamilyModelManager class that utilizes the pagination enabled QuerySet
* Fixed a bug in the database backend compiler.py where query limit statement was not being applied.