### PR TITLE
Fixing Failure In Updating Models With Virtual Token Partition Key Fi…

### DIFF
--- a/djangocassandra/db/backends/cassandra/compiler.py
+++ b/djangocassandra/db/backends/cassandra/compiler.py
@@ -244,7 +244,11 @@ class CassandraQuery(NonrelQuery):
         if None is self.root_predicate:
             raise Exception('No root query node')
 
-        if high_mark is not None and high_mark <= low_mark:
+        if (
+            high_mark is not None and
+            low_mark is not None and
+            high_mark <= low_mark
+        ):
             return
 
         if not low_mark and high_mark:
@@ -439,6 +443,9 @@ class SQLInsertCompiler(
 
         with BatchQuery() as b:
             for row in values:
+                if 'pk__token' in row:
+                    del row['pk__token']
+
                 if meta.has_auto_field and meta.pk.column not in row.keys():
                     if meta.pk.get_internal_type() == 'AutoField':
                         '''
@@ -488,6 +495,9 @@ class SQLUpdateCompiler(
         fields = []
         for value in values:
             field = value[0]
+            if 'Token' == field.get_internal_type():
+                continue
+
             fields.append(field)
             value_dict[
                 field.db_column

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.2.1',
+    version='0.2.2',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
…elds

* Apparently when you mark a model field editable=False django still passes values for these fields back to the database backend for inserts and updates. This is handled correctly now (pk__token field is removed from insert/update queries).