### PR TITLE
Inefficent Queries (get/filter) Don't Return Results In Some Cases

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,1 @@
+python setup.py sdist && cp dist/djangocassandra-0.0.4.tar.gz ../knotis.com/web/dist/ && docker exec knotiscom_web_1 /srv/knotis/venv/bin/pip install --upgrade --no-deps /srv/knotis/web/dist/djangocassandra-0.0.4.tar.gz

--- a/djangocassandra/db/backends/cassandra/compiler.py
+++ b/djangocassandra/db/backends/cassandra/compiler.py
@@ -77,7 +77,8 @@ class CassandraQuery(NonrelQuery):
             self.columns.append(f)
 
         self.where = None
-        self.limit = 1000000  # TODO: Make this a config setting
+        self.default_limit = 1000000  # TODO: Make this a config setting
+        self.limit = self.default_limit
         self.timeout = None  # TODO: Make this a config setting
         self.cache = None
         self.allows_inefficient = (
@@ -230,7 +231,7 @@ class CassandraQuery(NonrelQuery):
         return self._get_rows_by_indexed_column(range_predicates)
 
     def get_all_rows(self):
-        return self.cql_query.all()
+        return self.cql_query.limit(self.default_limit).all()
 
     def _get_query_results(self):
         if None is self.cache:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.2.2',
+    version='0.2.3',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -34,7 +34,7 @@ class DatabaseSimpleQueryTestCase(TestCase):
         ]
         field_values = ['foo', 'bar', 'raw', 'awk', 'lik', 'sik', 'dik', 'doc']
 
-        self.total_rows = 10
+        self.total_rows = 400
         for x in xrange(self.total_rows):
             test_data = {}
             i = 0
@@ -53,6 +53,18 @@ class DatabaseSimpleQueryTestCase(TestCase):
 
     def tearDown(self):
         destroy_db(self.connection)
+
+    def test_filter_on_unindexed_column(self):
+        field_3_filter = SimpleTestModel.objects.filter(field_3='raw')
+
+        expected_count = 0
+        for _, o in self.cached_rows.iteritems():
+            if o.field_3 == 'raw':
+                expected_count += 1
+
+        self.assertEqual(expected_count, len(field_3_filter))
+        for o in field_3_filter:
+            self.assertTrue(o.pk in self.cached_rows.keys())
 
     def test_query_all(self):
         all_rows = list(SimpleTestModel.objects.all())


### PR DESCRIPTION
Nasty bug here where for inefficient queries the limit on the query wasn't being reset. Somewhere in the get/filter django sets a limit to 21 (I think this is MAX_GET_RESULTS +1; use grep to find if curious). When there were more than 21 results in the query set there was a good chance that the result that matches the provided filter would not be in the result set.