### PR TITLE
Fix Results Not Being Returned For Inefficient Queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.2.5',
+    version='0.2.6',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -43,6 +43,23 @@ class ColumnFamilyTestModel(ColumnFamilyModel):
     )
 
 
+class ColumnFamilyIndexedTestModel(ColumnFamilyModel):
+    field_1 = CharField(
+        primary_key=True,
+        max_length=32
+    )
+    field_2 = CharField(
+        max_length=32
+    )
+    field_3 = CharField(
+        max_length=32
+    )
+    field_4 = CharField(
+        max_length=32,
+        db_index=True
+    )
+
+    
 class SimpleTestModel(Model):
     field_1 = CharField(max_length=32)
     field_2 = CharField(max_length=32)

--- a/tests/test_columnfamily.py
+++ b/tests/test_columnfamily.py
@@ -2,7 +2,8 @@ from random import randint
 from unittest import TestCase
 
 from .models import (
-    ColumnFamilyTestModel
+    ColumnFamilyTestModel,
+    ColumnFamilyIndexedTestModel
 )
 
 from .util import (
@@ -71,3 +72,90 @@ class ColumnFamilyModelTestCase(TestCase):
 
         result = token_field.value_to_string(first_instance)
         self.assertIsNotNone(result)
+
+
+class ColumnFamilyTestIndexedQueriesTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+        self.cached_rows = {}
+
+        '''
+        Let's create some simple data.
+        '''
+        create_model(
+            self.connection,
+            ColumnFamilyIndexedTestModel
+        )
+
+        field_names = [
+            field.name if field.get_internal_type() != 'AutoField' else None
+            for field in ColumnFamilyIndexedTestModel._meta.fields
+        ]
+        field_values = [
+            'foo',
+            'bar',
+            'raw',
+            'awk',
+            'lik',
+            'sik',
+            'dik',
+            'doc',
+            'dab'
+        ]
+        high_cardinality_field_values = ['yes', 'no']
+
+        self.total_rows = 400
+        value_index = 0
+        for x in xrange(self.total_rows):
+            test_data = {}
+            for name in field_names:
+                if not name:
+                    continue
+
+                test_data[name] = field_values[value_index % len(field_values)]
+                test_data['field_4'] = (
+                    high_cardinality_field_values[
+                        value_index % len(
+                            high_cardinality_field_values
+                        )
+                    ]
+                )
+                value_index += 1
+
+            test_data['field_1'] = test_data['field_1'] + str(
+                randint(1000, 9999)
+            )
+
+            if test_data['field_1'] in self.cached_rows.keys():
+                continue
+
+            created_instance = ColumnFamilyIndexedTestModel.objects.create(
+                **test_data
+            )
+            self.cached_rows[created_instance.pk] = created_instance
+
+        self.created_instances = len(self.cached_rows)
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_partial_inefficient_get_query(self):
+        all_results = ColumnFamilyIndexedTestModel.objects.all()
+        all_results = [x for x in all_results]
+        last_result = all_results[-1]
+        last_result.field_3 = 'tool'
+        last_result_indexed_value = last_result.field_4
+        last_result.save()
+
+        partial_inefficient_get = (
+            ColumnFamilyIndexedTestModel.objects.get(
+                field_3='tool',
+                field_4=last_result_indexed_value
+            )
+        )
+
+        self.assertIsNotNone(partial_inefficient_get)
+        self.assertTrue(partial_inefficient_get.pk in self.cached_rows.keys())


### PR DESCRIPTION
get() calls we not returning results in a case where the result you wanted was more that 21 rows deep due to a bug in the way result slices were applied. Implemented a fix and a unit test to cover the fixed case.