### PR TITLE
Compound Partition Keys

### DIFF
--- a/djangocassandra/db/backends/cassandra/exceptions.py
+++ b/djangocassandra/db/backends/cassandra/exceptions.py
@@ -2,6 +2,7 @@ from django.db import (
     NotSupportedError
 )
 
+
 class InefficientQueryError(NotSupportedError):
     message = (
         'Innefficent queries are not allowed on this model. '
@@ -13,7 +14,7 @@ class InefficientQueryError(NotSupportedError):
         'inefficient filtering and ordering in your database '
         'by setting the ALLOW_INEFFICIENT_QUERIES=True in '
         'your settings.py or you can set this per model in '
-        'the CassandraMeta class for you model '
+        'the Cassandra meta class for you model '
         '"allow_inefficient_queries=True".'
     )
 

--- a/djangocassandra/db/backends/cassandra/predicate.py
+++ b/djangocassandra/db/backends/cassandra/predicate.py
@@ -88,22 +88,22 @@ class RangePredicate(object):
 
     def can_evaluate_efficiently(
         self,
-        pk_column,
+        partition_columns,
         clustering_columns,
         indexed_columns
     ):
         if self._is_exact():
-            return (
-                self.column == pk_column or
-                self.column == 'pk__token' or
-                self.column in indexed_columns or
-                self.column in clustering_columns
+            return self.column in itertools.chain(
+                ['pk__token'],
+                partition_columns,
+                clustering_columns,
+                indexed_columns
             )
 
         else:
             return self.column in itertools.chain(
-                clustering_columns,
-                ['pk__token']
+                ['pk__token'],
+                clustering_columns
             )
 
     def incorporate_range_op(self, column, op, value, parent_compound_op):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.2.6',
+    version='0.2.7',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -145,7 +145,7 @@ class RelatedModelC(Model):
 
 
 class ClusterPrimaryKeyModel(Model):
-    class CassandraMeta:
+    class Cassandra:
         clustering_keys = ['field_2', 'field_3']
 
     field_1 = CharField(
@@ -154,4 +154,19 @@ class ClusterPrimaryKeyModel(Model):
     )
     field_2 = CharField(max_length=32)
     field_3 = CharField(max_length=32)
+    data = CharField(max_length=64)
+
+
+class PartitionPrimaryKeyModel(Model):
+    class Cassandra:
+        partition_keys = ['field_1', 'field_2']
+        clustering_keys = ['field_3', 'field_4']
+
+    field_1 = CharField(
+        primary_key=True,
+        max_length=32
+    )
+    field_2 = CharField(max_length=32)
+    field_3 = CharField(max_length=32)
+    field_4 = CharField(max_length=32)
     data = CharField(max_length=64)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from .models import (
     SimpleTestModel,
+    PartitionPrimaryKeyModel,
     ClusterPrimaryKeyModel,
     ColumnFamilyTestModel
 )
@@ -148,6 +149,9 @@ class DatabaseClusteringKeyTestCase(TestCase):
         import django
         django.setup()
 
+    def tearDown(self):
+        destroy_db(self.connection)
+
     def inefficient_filter(self):
         manager = ClusterPrimaryKeyModel.objects
         all_rows = list(manager.all())
@@ -285,6 +289,63 @@ class DatabaseClusteringKeyTestCase(TestCase):
                 filtered_rows[i].data,
                 filtered_rows_ordered_desc[i].data
             )
+
+
+class DatabasePartitionKeyTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        self.cached_rows = {}
+
+        '''
+        Now let's create some data that is clustered
+        '''
+        create_model(
+            self.connection,
+            PartitionPrimaryKeyModel
+        )
+
+        manager = PartitionPrimaryKeyModel.objects
+        manager.create(
+            field_1='aaaa',
+            field_2='aaaa',
+            field_3='bbbb',
+            field_4='cccc',
+            data='Foo'
+        )
+
+        manager.create(
+            field_1='aaaa',
+            field_2='bbbb',
+            field_3='cccc',
+            field_4='dddd',
+            data='Tao'
+        )
+
+        manager.create(
+            field_1='bbbb',
+            field_2='aaaa',
+            field_3='aaaa',
+            field_4='eeee',
+            data='Bar'
+        )
+
+        manager.create(
+            field_1='bbbb',
+            field_2='bbbb',
+            field_3='aaaa',
+            field_4='ffff',
+            data='Lel'
+        )
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_nothing(self):
+        pass
 
 
 class ColumnFamilyModelPagingQueryTestCase(TestCase):


### PR DESCRIPTION
* Added support for defining compound partition keys. define partition_keys member in Cassandra options class on your model definition.
* The classname for Cassandra options was not consistent. changed all instances of 'CassandraMeta' to 'Cassandra'