### PR TITLE
Fixed Cassandra Options Having No Effect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.2.7',
+    version='0.2.8',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -170,3 +170,33 @@ class PartitionPrimaryKeyModel(Model):
     field_3 = CharField(max_length=32)
     field_4 = CharField(max_length=32)
     data = CharField(max_length=64)
+
+
+class AbstractTestModel(Model):
+    class Meta:
+        abstract = True
+
+    inherited_1 = CharField(
+        max_length=32,
+        db_index=True
+    )
+    inherited_2 = CharField(max_length=32)
+    pub_date = DateTimeField('date published', auto_now_add=True)
+
+
+class DerivedPartitionPrimaryKeyModel(AbstractTestModel):
+    class Cassandra:
+        partition_keys = ['field_1', 'field_2']
+        clustering_keys = ['inherited_1', 'pub_date']
+
+    field_1 = CharField(
+        primary_key=True,
+        max_length=32
+    )
+    field_2 = CharField(
+        max_length=32,
+        db_index=True
+    )
+    data = CharField(
+        max_length=128
+    )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from .models import (
     SimpleTestModel,
+    DerivedPartitionPrimaryKeyModel,
     PartitionPrimaryKeyModel,
     ClusterPrimaryKeyModel,
     ColumnFamilyTestModel
@@ -335,6 +336,63 @@ class DatabasePartitionKeyTestCase(TestCase):
             field_2='bbbb',
             field_3='aaaa',
             field_4='ffff',
+            data='Lel'
+        )
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_nothing(self):
+        pass
+
+
+class DerivedPartitionKeyModelTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        self.cached_rows = {}
+
+        '''
+        Now let's create some data that is clustered
+        '''
+        create_model(
+            self.connection,
+            DerivedPartitionPrimaryKeyModel
+        )
+
+        manager = DerivedPartitionPrimaryKeyModel.objects
+        manager.create(
+            field_1='aaaa',
+            field_2='aaaa',
+            inherited_1='bbbb',
+            inherited_2='cccc',
+            data='Foo'
+        )
+
+        manager.create(
+            field_1='aaaa',
+            field_2='bbbb',
+            inherited_1='cccc',
+            inherited_2='dddd',
+            data='Tao'
+        )
+
+        manager.create(
+            field_1='bbbb',
+            field_2='aaaa',
+            inherited_1='aaaa',
+            inherited_2='eeee',
+            data='Bar'
+        )
+
+        manager.create(
+            field_1='bbbb',
+            field_2='bbbb',
+            inherited_1='aaaa',
+            inherited_2='ffff',
             data='Lel'
         )
 


### PR DESCRIPTION
* The way django passes models to the backend seems to be different than how I'm invoking it in the tests. I added some special model fetching code to make sure we're getting the class as defined including the "Cassandra" options class that holds the definition for partition and clustering keys.