### PR TITLE
Partition/Cluster Primary Key Models With Mutltiple Fields Fail on In…

### DIFF
--- a/djangocassandra/db/models.py
+++ b/djangocassandra/db/models.py
@@ -27,4 +27,17 @@ class ColumnFamilyModel(DjangoModel):
             **kwargs
         )
 
+    def save(
+            self,
+            *args,
+            **kwargs
+    ):
+        kwargs['force_insert'] = True
+        kwargs['force_update'] = False
+
+        return super(ColumnFamilyModel, self).save(
+            *args,
+            **kwargs
+        )
+
     objects = ColumnFamilyManager()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.3.4',
+    version='0.3.6',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -29,6 +29,8 @@ from django.db.models import (
 from djangocassandra.db.fields import AutoFieldUUID
 from djangocassandra.db.models import ColumnFamilyModel
 
+from util import random_string
+
 
 class ColumnFamilyTestModel(ColumnFamilyModel):
     field_1 = CharField(
@@ -59,11 +61,16 @@ class ColumnFamilyIndexedTestModel(ColumnFamilyModel):
         db_index=True
     )
 
-    
+
 class SimpleTestModel(Model):
     field_1 = CharField(max_length=32)
     field_2 = CharField(max_length=32)
     field_3 = CharField(max_length=32)
+
+
+class CustomNameTestModel(SimpleTestModel):
+    class Meta:
+        db_table = 'custom_model_testtesttest'
 
 
 class DateTimeTestModel(Model):
@@ -144,7 +151,7 @@ class RelatedModelC(Model):
     )
 
 
-class ClusterPrimaryKeyModel(Model):
+class ClusterPrimaryKeyModel(ColumnFamilyModel):
     class Cassandra:
         clustering_keys = ['field_2', 'field_3']
 
@@ -156,8 +163,14 @@ class ClusterPrimaryKeyModel(Model):
     field_3 = CharField(max_length=32)
     data = CharField(max_length=64)
 
+    def auto_populate(self):
+        self.field_1 = random_string(32)
+        self.field_2 = random_string(32)
+        self.field_3 = random_string(32)
+        self.data = random_string(64)
 
-class PartitionPrimaryKeyModel(Model):
+
+class PartitionPrimaryKeyModel(ColumnFamilyModel):
     class Cassandra:
         partition_keys = ['field_1', 'field_2']
         clustering_keys = ['field_3', 'field_4']
@@ -170,6 +183,13 @@ class PartitionPrimaryKeyModel(Model):
     field_3 = CharField(max_length=32)
     field_4 = CharField(max_length=32)
     data = CharField(max_length=64)
+
+    def auto_populate(self):
+        self.field_1 = random_string(32)
+        self.field_2 = random_string(32)
+        self.field_3 = random_string(32)
+        self.field_4 = random_string(32)
+        self.data = random_string(64)
 
 
 class AbstractTestModel(Model):

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -6,7 +6,10 @@ from .util import (
     create_model
 )
 
-from .models import SimpleTestModel
+from .models import (
+    SimpleTestModel,
+    CustomNameTestModel
+)
 
 
 class DatabaseCreationTestCase(TestCase):
@@ -20,4 +23,10 @@ class DatabaseCreationTestCase(TestCase):
         create_model(
             self.connection,
             SimpleTestModel
+        )
+
+    def test_table_name(self):
+        create_model(
+            self.connection,
+            CustomNameTestModel
         )

--- a/tests/test_insertion.py
+++ b/tests/test_insertion.py
@@ -7,7 +7,9 @@ from djangocassandra.db.meta import get_column_family
 from .models import (
     SimpleTestModel,
     DateTimeTestModel,
-    ComplicatedTestModel
+    ComplicatedTestModel,
+    PartitionPrimaryKeyModel,
+    ClusterPrimaryKeyModel
 )
 
 from .util import (
@@ -34,6 +36,16 @@ class DatabaseInsertionTestCase(TestCase):
         create_model(
             self.connection,
             ComplicatedTestModel
+        )
+
+        create_model(
+            self.connection,
+            PartitionPrimaryKeyModel
+        )
+
+        create_model(
+            self.connection,
+            ClusterPrimaryKeyModel
         )
 
     def tearDown(self):
@@ -74,6 +86,20 @@ class DatabaseInsertionTestCase(TestCase):
 
     def test_complicated_insertion(self):
         instance = ComplicatedTestModel()
+        instance.auto_populate()
+        instance.save()
+        self.assertIsNotNone(instance)
+        self.assertIsNotNone(instance.pk)
+
+    def test_partition_key_test_model(self):
+        instance = PartitionPrimaryKeyModel()
+        instance.auto_populate()
+        instance.save()
+        self.assertIsNotNone(instance)
+        self.assertIsNotNone(instance.pk)
+
+    def test_clustering_key_test_model(self):
+        instance = ClusterPrimaryKeyModel()
         instance.auto_populate()
         instance.save()
         self.assertIsNotNone(instance)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,9 @@
+import sys
+import random
+random.seed()
+
+import string
+
 from django.conf import settings
 
 from cassandra.cqlengine.management import delete_keyspace
@@ -31,3 +37,17 @@ def destroy_db(connection):
         ]
         for keyspace in keyspace_names:
             delete_keyspace(keyspace)
+
+
+def random_float(minimum=sys.float_info.min, maximum=sys.float_info.max):
+    return random.uniform(minimum, maximum)
+
+
+def random_integer(minimum=0, maximum=sys.maxint):
+    return random.randint(minimum, maximum)
+
+
+def random_string(length=8):
+    return ''.join(
+        random.choice(string.ascii_letters) for x in xrange(length)
+    )


### PR DESCRIPTION
…sert

There was an issue where Django decides to do an update instead of an insert which causes a malformed CQL query on the backend. I made a change to ColumnFamily model save method where it always passes force_insert=True. ColumnFamily is now required to utilize partition and clustering keys.

Added some tests to cover this.