### PR TITLE
Configurable Allow Inefficient and Improved AutoFieldUUID

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -82,6 +82,19 @@ class AutoFieldUUID(with_metaclass(SubfieldBase, AutoField)):
         'invalid': _("'%(value)s' value must be a valid UUID."),
     }
 
+    def __init__(
+        self,
+        *args,
+        **kwargs
+    ):
+        if 'default' not in kwargs:
+            kwargs['default'] = uuid.uuid4
+
+        super(AutoFieldUUID, self).__init__(
+            *args,
+            **kwargs
+        )
+
     def to_python(
         self,
         value
@@ -105,6 +118,7 @@ class AutoFieldUUID(with_metaclass(SubfieldBase, AutoField)):
     def get_internal_type(self):
         return 'AutoFieldUUID'
 
+    @staticmethod
     def get_auto_value(self):
         return uuid.uuid4()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.3.6',
+    version='0.3.7',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Made allow_inefficient flag to be set in the model Cassandra sub class or as a setting in the database configuration in settings.py.
* Improved AutoFieldUUID to auto populate even if it isn't a primary key by setting a default default value function to uuid.uuid4.