### PR TITLE
Foreign Key Fields Not Created Properly In Meta Class

### DIFF
--- a/djangocassandra/db/backends/cassandra/compiler.py
+++ b/djangocassandra/db/backends/cassandra/compiler.py
@@ -1,9 +1,11 @@
+import re
 import itertools
 
 from django.db.utils import (
     ProgrammingError
 )
 
+from django.db.models import ForeignKey
 from django.db.models.sql.constants import MULTI
 from django.db.models.sql.where import (
     WhereNode,
@@ -389,9 +391,18 @@ class CassandraQuery(NonrelQuery):
             for partition_key in self.partition_columns:
                 found = False
                 for filter_tuple in self.filters:
-                    if partition_key == filter_tuple[0].name:
+                    field = filter_tuple[0]
+                    if isinstance(field, ForeignKey):
+                        partition_key = re.sub(
+                            '_id$',
+                            '',
+                            partition_key
+                        )
+
+                    if partition_key == field.name:
                         found = True
-                        break
+                        continue
+
                 if not found:
                     partition_key_filtered = False
                     break

--- a/djangocassandra/db/meta.py
+++ b/djangocassandra/db/meta.py
@@ -59,7 +59,7 @@ def get_cql_column_type(field):
     internal_type = field.get_internal_type()
     if internal_type == 'ForeignKey':
         internal_type = (
-            field.related.model._meta.pk.get_internal_type()
+            field.rel.to._meta.pk.get_internal_type()
         )
 
     return internal_type_to_column_map[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.4.5',
+    version='0.4.6',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -287,3 +287,21 @@ class DenormalizedModelB(DenormalizedModelBase):
     created = DateTimeField(
         default=datetime.datetime.utcnow
     )
+
+
+class ForeignPartitionKeyModel(ColumnFamilyModel):
+    class Cassandra:
+        partition_keys = [
+            'related'
+        ]
+        clustering_keys = [
+            'created'
+        ]
+
+    related = ForeignKey(
+        ClusterPrimaryKeyModel,
+        primary_key=True
+    )
+    created = DateTimeField(
+        default=datetime.datetime.utcnow
+    )


### PR DESCRIPTION
* Fixed foreign key relations not being created correctly on the cqlengine side.
* Fixed order_by not correctly detecting when ForeginKey partition key fields were properly filtered for the query.