### PR TITLE
Introspection table_names method needs default param.

### DIFF
--- a/djangocassandra/db/backends/cassandra/introspection.py
+++ b/djangocassandra/db/backends/cassandra/introspection.py
@@ -41,5 +41,5 @@ class DatabaseIntrospection(NonrelDatabaseIntrospection):
 
         return [row['columnfamily_name'] for row in table_list]
 
-    def table_names(self, cursor):
+    def table_names(self, cursor=None):
         return BaseDatabaseIntrospection.table_names(self, cursor)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.4.6',
+    version='0.4.7',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
There are cases (when running tests) where Django calls table_names without passing a cursor object. Default is now None.