### PR TITLE
Sqlflush Management Command Support

### DIFF
--- a/djangocassandra/db/backends/cassandra/base.py
+++ b/djangocassandra/db/backends/cassandra/base.py
@@ -47,9 +47,25 @@ class DatabaseOperations(NonrelDatabaseOperations):
         self,
         style,
         tables,
-        sequence_list
+        sequence_list,
+        allow_cascade=False
     ):
-        raise Exception('Not Implemented')
+        if tables:
+            cql = [
+                'use %s;' % (
+                    style.SQL_FIELD(self.connection.keyspace),
+                )
+            ]
+            for table in tables:
+                cql.append('%s %s;' % (
+                    style.SQL_KEYWORD('TRUNCATE'),
+                    style.SQL_FIELD(self.quote_name(table))
+                ))
+
+            return cql
+
+        else:
+            return []
 
     def _value_for_db(
         self,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.4.7',
+    version='0.4.8',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -29,19 +29,27 @@ class OperationsTestCase(TestCase):
         destroy_db(self.connection)
 
     def test_flush(self):
-        try:
-            self.connection.ops.sql_flush(
-                None, [
-                    'ColumnFamilyTestModel'
-                ],
-                None
-            )
-            self.assertTrue(False)
+        from django.core.management.color import no_style
 
-        except Exception, e:
-            self.assertEqual(
-                e.message,
-                'Not Implemented'
+        test_model_names = ['testmodel']
+        cql = self.connection.ops.sql_flush(
+            no_style(),
+            test_model_names,
+            ()
+        )
+
+        self.assertEquals(
+            2,
+            len(cql)
+        )
+        self.assertEquals(
+            'use %s;' % (self.connection.keyspace,),
+            cql[0].lower()
+        )
+        for i in xrange(len(test_model_names)):
+            self.assertEquals(
+                'truncate %s;' % (test_model_names[i],),
+                cql[i + 1].lower()
             )
 
     def test_value_to_db_auto(self):


### PR DESCRIPTION
* Running Django tests requires support for the sqlflush management command. It returns an array of CQL commands to be executed against the server. The first statement is a use statement for the keyspace for the current connection and the rest are TRUNCATE statements for each table passed in.