### PR TITLE
Fix Cursor Execute

### DIFF
--- a/djangocassandra/db/backends/cassandra/cursor.py
+++ b/djangocassandra/db/backends/cassandra/cursor.py
@@ -81,7 +81,9 @@ class CassandraCursor(object):
     def execute(self, query, args=None):
         self.rows = self.session.execute(query, args)
         self.index = 0
-        self._with_rows = 0 != len(self.rows)
+        self._with_rows = (
+            None is not self.rows and len(self.rows)
+        )
 
         return self.rows
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.4.8',
+    version='0.4.9',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Cursor.execute method was throwing exceptions for queries that do not return results. I modified the check for _with_rows to handle None results.