### PR TITLE
Handle EmptyResultSet Exception

### DIFF
--- a/djangocassandra/db/backends/cassandra/exceptions.py
+++ b/djangocassandra/db/backends/cassandra/exceptions.py
@@ -23,3 +23,15 @@ class InefficientQueryError(NotSupportedError):
 
     def __str__(self):
         return  (self.message + ':\n%s') % (repr(self.query),)
+
+
+class InvalidQueryOpException(NotSupportedError):
+    message = (
+        'The operation %s is not supported.'
+    )
+
+    def __init__(self, operation):
+        self.operation = operation
+
+    def __str__(self):
+        return (self.message + ':\n%s') % (repr(self.operation),)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.4.9',
+    version='0.5.0',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* EmptyResultSet exception gets bubbled up when the django test suite does a in lookup with no values causing tests to fail.