### PR TITLE
Fix Token Field Serialization

### DIFF
--- a/djangocassandra/db/fields.py
+++ b/djangocassandra/db/fields.py
@@ -102,7 +102,7 @@ class TokenPartitionKeyField(Field):
         value = self._get_val_from_obj(obj)
         return ''.join([
             'token(',
-            ','.join(value.value),
+            ','.join(str(value.value)),
             ')'
         ])
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.5.1',
+    version='0.5.2',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Serializing tokens with UUID values was broken. Wrapped value in a str() call to prevent this.