### PR TITLE
Fix DictField Support

### DIFF
--- a/djangocassandra/db/backends/cassandra/base.py
+++ b/djangocassandra/db/backends/cassandra/base.py
@@ -75,6 +75,9 @@ class DatabaseOperations(NonrelDatabaseOperations):
         db_type,
         lookup
     ):
+        if 'DictField' == field_kind:
+            return value
+
         return super(DatabaseOperations, self)._value_for_db(
             value,
             field,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.5.2',
+    version='0.5.3',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,6 +26,7 @@ from django.db.models import (
     ForeignKey
 )
 
+from djangotoolbox.fields import DictField
 from djangocassandra.db.fields import (
     AutoFieldUUID,
     FieldUUID
@@ -305,3 +306,8 @@ class ForeignPartitionKeyModel(ColumnFamilyModel):
     created = DateTimeField(
         default=datetime.datetime.utcnow
     )
+
+
+class DictFieldModel(ColumnFamilyModel):
+    id = AutoFieldUUID(primary_key=True)
+    parameters = DictField(CharField(max_length=4096))

--- a/tests/test_columnfamily.py
+++ b/tests/test_columnfamily.py
@@ -6,7 +6,8 @@ from .models import (
     ColumnFamilyTestModel,
     ColumnFamilyIndexedTestModel,
     ClusterPrimaryKeyModel,
-    ForeignPartitionKeyModel
+    ForeignPartitionKeyModel,
+    DictFieldModel
 )
 
 from .util import (
@@ -209,3 +210,26 @@ class ForeignPartitionKeyModelTestCase(TestCase):
                 10,
                 len(results)
             )
+
+
+class TestDictFieldModel(TestCase):
+    def setUp(self):
+        import django
+        django.setup()
+
+        self.connection = connect_db()
+
+        create_model(
+            self.connection,
+            DictFieldModel
+        )
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_creation(self):
+        instance = DictFieldModel.objects.create(
+            parameters={'key0': 'value0', 'key1': 'value1'}
+        )
+
+        self.assertIsNotNone(instance)


### PR DESCRIPTION
* DictFields were not returning an appropriate value for our database backend. The backend expects a python dict but it was being converted into an array of tuples. I modified the to_database method to leave the value as is in this case.
* Created a unit test to cover this.