### PR TITLE
Fix Model Meta Class __new__

### DIFF
--- a/djangocassandra/db/meta.py
+++ b/djangocassandra/db/meta.py
@@ -121,7 +121,7 @@ class CqlColumnFamilyMetaClass(CqlEngineModelMetaClass):
 
             if partition_keys:
                 for column_name in partition_keys:
-                    field = model._meta.get_field(column_name)
+                    field = registered_model._meta.get_field(column_name)
                     field_name = (
                         field.db_column if
                         field.db_column else
@@ -141,7 +141,7 @@ class CqlColumnFamilyMetaClass(CqlEngineModelMetaClass):
                     ] = column
 
             else:
-                primary_key_field = model._meta.pk
+                primary_key_field = registered_model._meta.pk
                 primary_field_name = (
                     primary_key_field.db_column
                     if primary_key_field.db_column
@@ -169,7 +169,7 @@ class CqlColumnFamilyMetaClass(CqlEngineModelMetaClass):
                 clustering_keys = cassandra_options.clustering_keys
 
                 for column_name in clustering_keys:
-                    field = model._meta.get_field(column_name)
+                    field = registered_model._meta.get_field(column_name)
                     field_name = (
                         field.db_column if
                         field.db_column else
@@ -194,7 +194,7 @@ class CqlColumnFamilyMetaClass(CqlEngineModelMetaClass):
                         field.column
                     ] = column
 
-            for field in model._meta.fields:
+            for field in registered_model._meta.fields:
                 if 'Token' == field.get_internal_type():
                     continue
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.5.3',
+    version='0.5.4',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Model meta class was using the passed in model instead of looking up the model registered with Django. I don't know what voodoo happens here but the passed in model does not have all the information required to properly render out the schema.