### PR TITLE
Upgrade to Cassandra Driver 3.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ docs/_build/
 tests/integration/ccm
 setuptools*.tar.gz
 setuptools*.egg
+.py/
 venv/
 doc/build/

--- a/djangocassandra/db/backends/cassandra/creation.py
+++ b/djangocassandra/db/backends/cassandra/creation.py
@@ -20,7 +20,8 @@ from cassandra.cqltypes import (
 )
 
 from cassandra.cqlengine.management import (
-    sync_table
+    sync_table,
+    create_keyspace_simple
 )
 
 from djangocassandra.db.meta import get_column_family
@@ -133,7 +134,11 @@ class DatabaseCreation(NonrelDatabaseCreation):
         style,  # Used for styling output
         known_models=set()
     ):
-        self.connection.create_keyspace()
+        create_keyspace_simple(
+            self.connection.keyspace,
+            1
+        )
+
         meta = model._meta
 
         if (

--- a/djangocassandra/db/backends/cassandra/predicate.py
+++ b/djangocassandra/db/backends/cassandra/predicate.py
@@ -499,6 +499,9 @@ class CompoundPredicate(object):
             )
 
             for row in results:
+                for key, value in cql_query._deferred_values.iteritems():
+                    row[key] = value
+
                 yield row
 
         result = paged_query_generator(

--- a/djangocassandra/db/backends/cassandra/schema.py
+++ b/djangocassandra/db/backends/cassandra/schema.py
@@ -30,7 +30,11 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
         self,
         model
     ):
-        self.connection.create_keyspace()
+        db_management.create_keyspace_simple(
+            self.connection.session.keyspace,
+            1
+        )
+
         column_family = get_column_family(
             self.connection,
             model

--- a/djangocassandra/db/meta.py
+++ b/djangocassandra/db/meta.py
@@ -27,7 +27,7 @@ internal_type_to_column_map = {
     'BooleanField': columns.Boolean,
     'CharField': columns.Text,
     'CommaSeparatedIntegerField': columns.Text,
-    'DateField': columns.Date,
+    'DateField': columns.DateTime,
     'DateTimeField': columns.DateTime,
     'DecimalField': columns.Decimal,
     'EmailField': columns.Text,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.5.4',
+    version='0.6.0',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '
@@ -40,7 +40,7 @@ setup(
     ],
     install_requires=[
         'django>=1.7, < 1.8',
-        'cassandra-driver==2.5.1',
+        'cassandra-driver==3.7.0',
         'blist',
         'djangotoolbox==1.7.0'
     ],

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -345,15 +345,19 @@ class DatabasePartitionKeyTestCase(TestCase):
     def tearDown(self):
         destroy_db(self.connection)
 
-    def test_nothing(self):
-        pass
-
     def test_in_filter(self):
         qs = PartitionPrimaryKeyModel.objects.filter(pk__in=[
             'aaaa',
             'bbbb'
         ])
         self.assertEqual(4, len(qs))
+
+    def test_filter_all_partition_keys(self):
+        qs = PartitionPrimaryKeyModel.objects.filter(
+            field_1='aaaa',
+            field_2='bbbb'
+        )
+        self.assertEqual(1, len(qs))
 
 
 class DerivedPartitionKeyModelTestCase(TestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,7 @@ import string
 
 from django.conf import settings
 
-from cassandra.cqlengine.management import delete_keyspace
+from cassandra.cqlengine.management import drop_keyspace
 
 from djangocassandra.db.backends.cassandra.base import DatabaseWrapper
 
@@ -36,7 +36,7 @@ def destroy_db(connection):
             key for key in settings.DATABASES['default']['KEYSPACES'].keys()
         ]
         for keyspace in keyspace_names:
-            delete_keyspace(keyspace)
+            drop_keyspace(keyspace)
 
 
 def random_float(minimum=sys.float_info.min, maximum=sys.float_info.max):


### PR DESCRIPTION
* Had to make some minor changes to support the new cqlengine api changes but now the backend supports Cassandra 3.x series.
* Incremented version to 0.6.0
* Reverted Django Date field to just use DateTime in cassandra to preserve backwards compatibility with Cassandra 2.x series.
* Added .py/ virtual environment directory to .gitignore.