### PR TITLE
Fix get_table_list in DatabaseIntrospection to Fix Migrations

### DIFF
--- a/djangocassandra/db/backends/cassandra/cursor.py
+++ b/djangocassandra/db/backends/cassandra/cursor.py
@@ -81,9 +81,17 @@ class CassandraCursor(object):
     def execute(self, query, args=None):
         self.rows = self.session.execute(query, args)
         self.index = 0
-        self._with_rows = (
-            None is not self.rows and len(self.rows)
-        )
+        if hasattr(self.rows, 'current_rows'):
+            self._with_rows = (
+                None is not self.rows and len(
+                    self.rows.current_rows
+                )
+            )
+
+        else:
+            self._with_rows = (
+                None is not self.rows and len(self.rows)
+            )
 
         return self.rows
 

--- a/djangocassandra/db/backends/cassandra/introspection.py
+++ b/djangocassandra/db/backends/cassandra/introspection.py
@@ -21,14 +21,34 @@ class DatabaseIntrospection(NonrelDatabaseIntrospection):
         ]
 
         table_list = []
+        '''
+        These are where the schema information for the cluster is
+        stored for Cassandra version 2.x
+        '''
+        schema_keyspace = 'system'
+        schema_table_name = 'schema_columnfamilies'
+        schema_table_name_field = 'columnfamily_name'
+
+        if 'system_schema' in self.connection.cluster.metadata.keyspaces:
+            '''
+            If there is a 'system_schema' keyspace then we are on
+            Cassandra 3.x and need to look for the schema info here.
+            '''
+            schema_keyspace = 'system_schema'
+            schema_table_name = 'tables'
+            schema_table_name_field = 'table_name'
+
         try:
-            cursor.set_keyspace('system')
+            cursor.set_keyspace(schema_keyspace)
             for keyspace in keyspaces:
                 table_list = itertools.chain(
                     table_list, cursor.execute(
                         ''.join([
-                            'SELECT columnfamily_name from ',
-                            'schema_columnfamilies where keyspace_name=\'',
+                            'SELECT ',
+                            schema_table_name_field,
+                            ' from ',
+                            schema_table_name,
+                            ' where keyspace_name=\'',
                             keyspace,  # TODO: SANITIZE ME JUST IN CASE!!!
                             '\''
                         ])
@@ -39,7 +59,7 @@ class DatabaseIntrospection(NonrelDatabaseIntrospection):
             if None is not current_keyspace:
                 cursor.set_keyspace(current_keyspace)
 
-        return [row['columnfamily_name'] for row in table_list]
+        return [row[schema_table_name_field] for row in table_list]
 
     def table_names(self, cursor=None):
         return BaseDatabaseIntrospection.table_names(self, cursor)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.6.0',
+    version='0.6.1',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,54 @@
+import datetime
+
+from unittest import TestCase
+
+from djangocassandra.db.meta import get_column_family
+
+from .models import (
+    SimpleTestModel,
+    DateTimeTestModel,
+    ComplicatedTestModel,
+    PartitionPrimaryKeyModel,
+    ClusterPrimaryKeyModel
+)
+
+from .util import (
+    connect_db,
+    create_model,
+    destroy_db
+)
+
+
+class DatabaseIntrospectionTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        self.models = [
+            SimpleTestModel,
+            PartitionPrimaryKeyModel
+        ]
+
+        for m in self.models:
+            create_model(
+                self.connection,
+                m
+            )
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_get_table_list(self):
+        table_list = self.connection.introspection.get_table_list()
+        self.assertIsNotNone(table_list)
+        self.assertEqual(
+            len(table_list),
+            len(self.models)
+        )
+        self.assertIn(
+            SimpleTestModel._meta.db_table,
+            table_list
+        )
+        self.assertIn(
+            PartitionPrimaryKeyModel._meta.db_table,
+            table_list
+        )


### PR DESCRIPTION
* Cassandra 3.x series stores database schema metadata in the keyspace system_schema instead of schema. They also changed some field names so I wrote some compatibility code.
* Wrote some compatibility code in cassandra cursor to handle a returned ResultSet instead of an array/dict
* Wrote a unit test to cover get_table_list.
* Incremented version to 0.6.1 since this hotfix is to be published immediately.