### PR TITLE
Fix Delete For Rows With Matching Partition Keys

### DIFF
--- a/djangocassandra/db/backends/cassandra/compiler.py
+++ b/djangocassandra/db/backends/cassandra/compiler.py
@@ -354,9 +354,14 @@ class CassandraQuery(NonrelQuery):
         else:
             rows = self.root_predicate.get_matching_rows(self)
             for row in rows:
-                self.column_family_class.get(**{
-                    field: row[field] for field in self.partition_columns
-                }).delete()
+                filterable_columns = itertools.chain(
+                    self.partition_columns,
+                    self.clustering_columns
+                )
+                query_parameters = {
+                    field: row[field] for field in filterable_columns
+                }
+                self.column_family_class.get(**query_parameters).delete()
 
     def order_by(
         self,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.6.3',
+    version='0.6.4',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/test_insertion.py
+++ b/tests/test_insertion.py
@@ -119,11 +119,24 @@ class DatabaseInsertionTestCase(TestCase):
             pass
 
     def test_partition_key_test_model(self):
-        instance = PartitionPrimaryKeyModel()
-        instance.auto_populate()
-        instance.save()
-        self.assertIsNotNone(instance)
-        self.assertIsNotNone(instance.pk)
+        instance_0 = PartitionPrimaryKeyModel()
+        instance_0.auto_populate()
+        instance_0.save()
+
+        self.assertIsNotNone(instance_0)
+        self.assertIsNotNone(instance_0.pk)
+
+        instance_1 = PartitionPrimaryKeyModel()
+        instance_1.auto_populate()
+        instance_1.field_1 = instance_0.field_1
+        instance_1.field_2 = instance_0.field_2
+        instance_1.save()
+
+        self.assertIsNotNone(instance_1)
+        self.assertIsNotNone(instance_1.pk)
+
+        instance_0.delete()
+        instance_1.delete()
 
     def test_clustering_key_test_model(self):
         instance = ClusterPrimaryKeyModel()


### PR DESCRIPTION
The delete method was only filtering on the instance's partition keys but not the clustering keys causing models with matching partition keys to run into MultipleRows exceptions in Cassandra while deleting.

* Fixed it so the delete method in the complier usins partition and clustering keys while generating the query.