### PR TITLE
Denormalize on Save Instead of on Create

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.6.5',
+    version='0.6.6',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Data only gets denormalized to denormalized_models on create() I changed it so it happens on save() so that the models stay consistent through their lifetime. (This still respects should_denormalize).
* Made it so delete() calls make the "should_denormalize" check to give the user more control over deletion behavior.