### PR TITLE
Primary Key Support (To Fix Deletion)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.6.6',
+    version='0.7.0',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,7 +8,6 @@ from django.db.models import (
     BooleanField,
     CommaSeparatedIntegerField,
     DateField,
-    DateTimeField,
     DecimalField,
     EmailField,
     FileField,
@@ -30,7 +29,9 @@ from django.db.models import (
 from djangotoolbox.fields import DictField
 from djangocassandra.db.fields import (
     AutoFieldUUID,
-    FieldUUID
+    FieldUUID,
+    PrimaryKeyField,
+    DateTimeField
 )
 from djangocassandra.db.models import (
     ColumnFamilyModel,
@@ -262,16 +263,16 @@ class DenormalizedModelBase(ColumnFamilyModel):
 class DenormalizedModelA(DenormalizedModelBase):
     class Cassandra:
         partition_keys = [
-            'field_1'
+            'field_1',
+            'field_2'
         ]
         clustering_keys = [
             'created'
         ]
 
-    field_1 = CharField(
-        max_length=16,
-        primary_key=True
-    )
+    field_1 = PrimaryKeyField(field_class=CharField, field_kwargs={
+        "max_length": 16
+    })
     field_2 = IntegerField()
     created = DateTimeField(
         default=datetime.datetime.utcnow
@@ -284,11 +285,14 @@ class DenormalizedModelB(DenormalizedModelBase):
             'field_2'
         ]
         clustering_keys = [
-            'created'
+            'created',
+            'field_1'
         ]
 
     field_1 = CharField(max_length=16)
-    field_2 = IntegerField(primary_key=True)
+    field_2 = PrimaryKeyField(
+        field_class=IntegerField
+    )
     created = DateTimeField(
         default=datetime.datetime.utcnow
     )


### PR DESCRIPTION
* Deletion depends on more robust primary key support. We were running into issues where unexpected rows were being deleted. This was caused by django matching just one field of the primary key (the one defined as primary_key=True). I implemented a new PrimaryKey field to handle this correctly. Calling .pk on a model now returns a PrimaryKeyValue object which is an OrderedDict subclass containing the key/values of the partition keys and the clustering keys.
* Modified denormalization tests to catch the above unexpected deletion issue.
* Added a new DateTimeField that truncates the nanoseconds off of date time since Cassandra doesn't support nanoseconds.
* Updated version string to minor revision 0.7.0