### PR TITLE
Fix Infinite Recursion When ForeignKey is part of Primary Key

### DIFF
--- a/djangocassandra/db/models.py
+++ b/djangocassandra/db/models.py
@@ -4,13 +4,17 @@ from collections import OrderedDict
 from django.apps import apps
 from django.db.models import (
     Model as DjangoModel,
-    Manager
+    Manager,
+    ForeignKey
 )
 from django.db.models.fields import (
     FieldDoesNotExist
 )
 
-from .fields import TokenPartitionKeyField
+from .fields import (
+    TokenPartitionKeyField,
+    PrimaryKeyField
+)
 
 from .query import QuerySet
 
@@ -118,7 +122,12 @@ class ColumnFamilyModel(DjangoModel):
             if 1 < len(all_keys):
                 pk_value = PrimaryKeyValue()
                 for key in all_keys:
-                    pk_value[key] = getattr(self, key)
+                    field = self._meta.get_field_by_name(key)[0]
+                    if isinstance(field, ForeignKey):
+                        pk_value[key] = getattr(self, key + "_id")
+
+                    else:
+                        pk_value[key] = getattr(self, key)
 
                 return pk_value
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.2',
+    version='0.7.3',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Fixed an infinite recursion where attemption to get the PK when a ForeignKey is part of the keys by getting the value instead of going throug Django ForeignKey __get__ logic repeatedly.