### PR TITLE
Primary Key Fixes

### DIFF
--- a/djangocassandra/db/models.py
+++ b/djangocassandra/db/models.py
@@ -11,11 +11,8 @@ from django.db.models.fields import (
     FieldDoesNotExist
 )
 
-from .fields import (
-    TokenPartitionKeyField,
-    PrimaryKeyField
-)
-
+from .fields import TokenPartitionKeyField
+from .values import PrimaryKeyValue
 from .query import QuerySet
 
 
@@ -58,22 +55,6 @@ class ColumnFamilyManager(Manager.from_queryset(QuerySet)):
 
         return instance
 
-
-class PrimaryKeyValue(OrderedDict):
-    def __int__(self):
-        return self.__hash__()
-
-    def __hash__(self):
-        return hash(self.to_tuple())
-
-    def __str__(self):
-        return str(self.to_tuple())
-
-    def __unicode__(self):
-        return unicode(self.to_tuple())
-
-    def to_tuple(self):
-        return tuple(self.iteritems())
 
 
 class ColumnFamilyModel(DjangoModel):
@@ -124,10 +105,12 @@ class ColumnFamilyModel(DjangoModel):
                 for key in all_keys:
                     field = self._meta.get_field_by_name(key)[0]
                     if isinstance(field, ForeignKey):
-                        pk_value[key] = getattr(self, key + "_id")
+                        key += "_id"
 
-                    else:
-                        pk_value[key] = getattr(self, key)
+                    pk_value[key] = field.get_prep_value(getattr(
+                        self,
+                        key
+                    ))
 
                 return pk_value
 

--- a/djangocassandra/db/values.py
+++ b/djangocassandra/db/values.py
@@ -1,0 +1,19 @@
+from collections import OrderedDict
+
+
+class PrimaryKeyValue(OrderedDict):
+    def __int__(self):
+        return self.__hash__()
+
+    def __hash__(self):
+        return hash(self.to_tuple())
+
+    def __str__(self):
+        return str(self.to_tuple())
+
+    def __unicode__(self):
+        return unicode(self.to_tuple())
+
+    def to_tuple(self):
+        return tuple(self.iteritems())
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.3',
+    version='0.7.4',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,7 @@
 import datetime
 
+from uuid import UUID
+
 from django.db.models import (
     DO_NOTHING,
     Model,
@@ -175,16 +177,14 @@ class ClusterPrimaryKeyModel(ColumnFamilyModel):
     class Cassandra:
         clustering_keys = ['field_2', 'field_3']
 
-    field_1 = CharField(
-        primary_key=True,
-        max_length=32
+    field_1 = FieldUUID(
+        primary_key=True
     )
     field_2 = CharField(max_length=32)
     field_3 = CharField(max_length=32)
     data = CharField(max_length=64)
 
     def auto_populate(self):
-        self.field_1 = random_string(32)
         self.field_2 = random_string(32)
         self.field_3 = random_string(32)
         self.data = random_string(64)
@@ -297,7 +297,6 @@ class DenormalizedModelB(DenormalizedModelBase):
         default=datetime.datetime.utcnow
     )
 
-
 class ForeignPartitionKeyModel(ColumnFamilyModel):
     class Cassandra:
         partition_keys = [
@@ -309,8 +308,7 @@ class ForeignPartitionKeyModel(ColumnFamilyModel):
 
     related = PrimaryKeyField(
         field_class=ForeignKey,
-        field_args=[ClusterPrimaryKeyModel],
-        field_kwargs={"primary_key": True}
+        field_args=[ClusterPrimaryKeyModel]
     )
     created = DateTimeField(
         default=datetime.datetime.utcnow

--- a/tests/test_columnfamily.py
+++ b/tests/test_columnfamily.py
@@ -211,6 +211,15 @@ class ForeignPartitionKeyModelTestCase(TestCase):
                 len(results)
             )
 
+        for i in instances:
+            i.delete()
+
+        all_instances = ForeignPartitionKeyModel.objects.all()
+        self.assertEqual(
+            0,
+            len(all_instances)
+        )
+
 
 class TestDictFieldModel(TestCase):
     def setUp(self):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,4 +1,5 @@
 import warnings
+import uuid
 
 from unittest import TestCase
 
@@ -119,29 +120,32 @@ class DatabaseClusteringKeyTestCase(TestCase):
         )
 
         manager = ClusterPrimaryKeyModel.objects
+
+        self.uuid0 = str(uuid.uuid4())
         manager.create(
-            field_1='aaaa',
+            field_1=self.uuid0,
             field_2='aaaa',
             field_3='bbbb',
             data='Foo'
         )
 
         manager.create(
-            field_1='aaaa',
+            field_1=self.uuid0,
             field_2='bbbb',
             field_3='cccc',
             data='Tao'
         )
 
+        self.uuid1 = str(uuid.uuid4())
         manager.create(
-            field_1='bbbb',
+            field_1=self.uuid1,
             field_2='aaaa',
             field_3='aaaa',
             data='Bar'
         )
 
         manager.create(
-            field_1='bbbb',
+            field_1=self.uuid1,
             field_2='bbbb',
             field_3='aaaa',
             data='Lel'
@@ -182,9 +186,9 @@ class DatabaseClusteringKeyTestCase(TestCase):
         manager = ClusterPrimaryKeyModel.objects
         all_rows = list(manager.all())
 
-        filtered_rows = list(manager.filter(field_1='bbbb'))
+        filtered_rows = list(manager.filter(field_1=self.uuid1))
 
-        filtered_rows_inmem = [r for r in all_rows if r.pk == 'bbbb']
+        filtered_rows_inmem = [r for r in all_rows if r.pk == self.uuid1]
 
         self.assertEqual(
             len(filtered_rows),
@@ -203,7 +207,7 @@ class DatabaseClusteringKeyTestCase(TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             filtered_rows = list(manager.filter(
-                field_1='bbbb',
+                field_1=self.uuid1,
                 field_2='aaaa',
                 field_3='aaaa'
             ))
@@ -215,7 +219,7 @@ class DatabaseClusteringKeyTestCase(TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             filtered_rows = list(manager.filter(
-                field_1='bbbb'
+                field_1=self.uuid1
             ).filter(
                 field_2='aaaa'
             ).filter(
@@ -229,7 +233,7 @@ class DatabaseClusteringKeyTestCase(TestCase):
 
         filtered_rows_inmem = [
             r for r in all_rows if
-            r.field_1 == 'bbbb' and
+            r.field_1 == self.uuid1 and
             r.field_2 == 'aaaa' and
             r.field_3 == 'aaaa'
         ]
@@ -247,20 +251,20 @@ class DatabaseClusteringKeyTestCase(TestCase):
 
     def test_orderby(self):
         manager = ClusterPrimaryKeyModel.objects
-        filtered_rows = list(manager.filter(field_1='bbbb'))
+        filtered_rows = list(manager.filter(field_1=self.uuid1))
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
 
             filtered_rows_ordered = list(
                 manager.filter(
-                    field_1='bbbb'
+                    field_1=self.uuid1
                 ).order_by('field_2')
             )
 
             filtered_rows_ordered_desc = list(
                 manager.filter(
-                    field_1='bbbb'
+                    field_1=self.uuid1
                 ).order_by('-field_2')
             )
 


### PR DESCRIPTION
* Fixed ColumnFamilyModel._get_pk_val to handle ForeignKey valued properly.
* Fixed PrimaryKeyField get_prep_value to handle ForeignKeys properly.
* Fixed FieldUUID and AutoFieldUUID get_prep_value methods to behave properly convert UUID values (and avoid trying to convert them to int).
* Fixed DateTimeField get_prep_value to always use 3 most significant digits.
* Modified unit tests to catch these edge cases.
* Refactored PrimaryKeyValue to values module since both fields and models modules require it.
* Incremented patch version to 0.7.4