### PR TITLE
Fix Migrations for DictField

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,16 @@ python:
 install:
     - "pip install ."
     - "pip install nose"
+    - pip install pillow
 
 env:
     - DJANGO_SETTINGS_MODULE=tests.settings
 
 services:
-      - cassandra
+    - cassandra
 
 before_script:
-  - pip install coveralls
+    - pip install coveralls
 
 script:
     - nosetests --with-coverage --cover-package=djangocassandra

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.5',
+    version='0.7.6',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '

--- a/tests/models.py
+++ b/tests/models.py
@@ -316,7 +316,12 @@ class ForeignPartitionKeyModel(ColumnFamilyModel):
         default=datetime.datetime.utcnow
     )
 
+def dict_field_default():
+    return {}
 
 class DictFieldModel(ColumnFamilyModel):
     id = AutoFieldUUID(primary_key=True)
-    parameters = DictField(CharField(max_length=4096))
+    parameters = DictField(
+        CharField(max_length=4096),
+        default=dict_field_default
+    )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from .util import (
+    connect_db,
+    destroy_db
+)
+
+
+class CommandsTestCase(TestCase):
+    def setUp(self):
+        self.connection = connect_db()
+
+        import django
+        django.setup()
+
+    def tearDown(self):
+        destroy_db(self.connection)
+
+    def test_migration(self):
+        from django.core.management import call_command
+        call_command('makemigrations')
+        call_command('migrate')


### PR DESCRIPTION
* Altering a dict field failed on migration since the _add_field method on the Schama class doesn't know how to create Map columns. This has been fixed.
* Added a unit test for testing django migration features.