### PR TITLE
Don't Try To Remove or Alter Fields

### DIFF
--- a/djangocassandra/db/backends/cassandra/schema.py
+++ b/djangocassandra/db/backends/cassandra/schema.py
@@ -134,7 +134,12 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
         model,
         field
     ):
-        self.create_model(model)
+        '''
+        Removing pk field is impossible and removing
+        other fields is unecessary. They will simply 
+        be ignored.
+        '''
+        pass
 
     def alter_field(
         self,
@@ -143,4 +148,10 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
         new_field,
         strict=False
     ):
-        self.create_model(model)
+        '''
+        Altering fields isn't well supported by 
+        the cassandra driver and these changes are
+        usually attributes only Django cares about
+        so pass...
+        '''
+        pass

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.7',
+    version='0.7.8',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* removing or altering attributes on fields isn't well supported by the python cassandra-driver. I'm removing this functionality now since it's busted and most alters only effect Django side validation anyway.