### PR TITLE
Ignore Old Indexed Fields When Adding New Field

### DIFF
--- a/djangocassandra/db/backends/cassandra/schema.py
+++ b/djangocassandra/db/backends/cassandra/schema.py
@@ -127,7 +127,22 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
         model,
         field
     ):
-        self.create_model(model)
+        column_family = get_column_family(
+            self.connection,
+            model
+        )
+
+        for key in column_family.keys():
+            '''
+            Turn off indexing for old fields or 
+            sync_table will try to recreate them
+            '''
+            if key is field.db_column:
+                continue
+
+            column_family._columns[key].index = False
+
+        self._create_db_table(column_family)
 
     def remove_field(
         self,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.8',
+    version='0.7.9',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* sync_table tries to recreate old secondary indexes when adding a new field. I fixed it so all old columns are set to index=False before syncing.