### PR TITLE
Fix Error in Add Field Method

### DIFF
--- a/djangocassandra/db/backends/cassandra/schema.py
+++ b/djangocassandra/db/backends/cassandra/schema.py
@@ -40,6 +40,7 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
             self.connection,
             model
         )
+
         self._create_db_table(column_family)
 
     def delete_model(
@@ -132,7 +133,7 @@ class CassandraSchemaEditor(BaseDatabaseSchemaEditor):
             model
         )
 
-        for key in column_family.keys():
+        for key in column_family._columns.keys():
             '''
             Turn off indexing for old fields or 
             sync_table will try to recreate them

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.7.9',
+    version='0.8.0',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '


### PR DESCRIPTION
* Add field was calling keys() method on uninstantiated column_family instance. Changed it to call keys on ._columns instead.