### PR TITLE
Support Django 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ setuptools*.egg
 .py/
 venv/
 doc/build/
+tests/migrations/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ python:
       - "2.7"
 
 install:
-    - "pip install ."
+    - "pip install . --process-dependency-links"
     - "pip install nose"
-    - pip install pillow
 
 env:
     - DJANGO_SETTINGS_MODULE=tests.settings

--- a/djangocassandra/db/backends/cassandra/introspection.py
+++ b/djangocassandra/db/backends/cassandra/introspection.py
@@ -1,6 +1,9 @@
 import itertools
 
-from django.db.backends import BaseDatabaseIntrospection
+from django.db.backends.base.introspection import (
+    BaseDatabaseIntrospection,
+    TableInfo
+)
 from djangotoolbox.db.base import NonrelDatabaseIntrospection
 
 
@@ -59,7 +62,7 @@ class DatabaseIntrospection(NonrelDatabaseIntrospection):
             if None is not current_keyspace:
                 cursor.set_keyspace(current_keyspace)
 
-        return [row[schema_table_name_field] for row in table_list]
+        return [TableInfo(row[schema_table_name_field], 't') for row in table_list]
 
     def table_names(self, cursor=None):
         return BaseDatabaseIntrospection.table_names(self, cursor)

--- a/djangocassandra/db/backends/cassandra/schema.py
+++ b/djangocassandra/db/backends/cassandra/schema.py
@@ -4,7 +4,7 @@ from cassandra.cqlengine.columns import (
     Text
 )
 
-from django.db.backends.schema import (
+from django.db.backends.base.schema import (
     BaseDatabaseSchemaEditor
 )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='djangocassandra',
-    version='0.8.0',
+    version='0.9.1',
     description='Cassandra support for the Django web framework',
     long_description=(
         'The Cassandra database backend for Django has been '
@@ -22,7 +22,7 @@ setup(
     license='BSD License',
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Framework :: Django :: 1.7',
+        'Framework :: Django :: 1.8',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
@@ -39,9 +39,13 @@ setup(
         'djangocassandra.db.backends.cassandra'
     ],
     install_requires=[
-        'django>=1.7, < 1.8',
+        'django==1.8.17',
         'cassandra-driver==3.7.0',
         'blist',
-        'djangotoolbox==1.7.0'
+        'djangotoolbox==1.8.1'
     ],
+    dependency_links=[(
+        'https://github.com/Knotis/djangotoolbox/'
+        'archive/master.tar.gz#egg=djangotoolbox-1.8.1'
+    )]
 )

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -44,11 +44,13 @@ class DatabaseIntrospectionTestCase(TestCase):
             len(table_list),
             len(self.models)
         )
+
+        table_names = [ti.name for ti in table_list]
         self.assertIn(
             SimpleTestModel._meta.db_table,
-            table_list
+            table_names
         )
         self.assertIn(
             PartitionPrimaryKeyModel._meta.db_table,
-            table_list
+            table_names
         )


### PR DESCRIPTION
* Fixed imports where the underlying modules have been moved in Django.
* get_table_list introspection now uses new TableInfo class to generate table metadata.
* Breaks Django <=1.7 support.